### PR TITLE
Sigilante/freshwater ray finned fish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 
 PROFILE_DEV_DEBUG = --profile dev
 PROFILE_RELEASE = --profile release
-HOONC = hoonc
+HOONC = ~/.cargo/bin/hoonc
 
 .PHONY: build
 build: build-dev-debug

--- a/common/hoon/lib/jock.hoon
+++ b/common/hoon/lib/jock.hoon
@@ -512,6 +512,8 @@
       [%fork p=jype q=jype]
       ::  %list
       [%list type=jype]
+      ::  %noun
+      [%noun p=jnoun-type]
       ::  %set
       [%set type=jype]
       ::  %hoon is a vase for the supplied subject (presumably hoon or tiny)
@@ -542,6 +544,12 @@
       %logical
       %date
       %span
+      %path
+  ==
+::  Jype noun base types; corresponds to jnoun tags
++$  jnoun-type
+  $+  jnoun-type
+  $?  %string
       %path
   ==
 ::  Jype core executable, either a direct lambda or a regular core
@@ -1271,7 +1279,7 @@
     [[%atom %number %.n] +.tokens]
   ::    Match on loobean type  a:?
   ?:  (has-punctuator -.tokens %'?')
-    [[%atom %loobean %.n] +.tokens]
+    [[%atom %logical %.n] +.tokens]
   ::  Match on noun type  a:*
   ?:  (has-punctuator -.tokens %'*')
     [[%none ~] +.tokens]
@@ -1409,9 +1417,9 @@
   ?:  =(~ tokens)  ~|("expect literal. token: ~" !!)
   ?.  ?=(%literal -<.tokens)
     ~|("expect literal. token: {<-<.tokens>}" !!)
-  ?:  ?=(%noun -<.tokens)
-    [[%noun -<.tokens] +.tokens]
-  [[%atom ->.tokens] +.tokens]
+  ?:  ?=(%noun ->-.tokens)
+    [[%noun ->+.tokens] +.tokens]
+  [[%atom ->+.tokens] +.tokens]
 ::
 ++  match-name
   |=  =tokens
@@ -1467,7 +1475,9 @@
   ?:  =(~ tokens)  ~|("expect literal. token: ~" !!)
   ?.  ?=(%literal -<.tokens)
     ~|("expect literal or symbol. token: {<-<.tokens>}" !!)
-  =/  p=jatom  ->.tokens
+  ?.  ?=(%atom ->-.tokens)
+    ~|("expect literal or symbol. token: {<-.tokens>}" !!)
+  =/  p=jatom  ->+.tokens
   ?.  ?=(%number -<.p)
     ~|("expect number or symbol. token: {<-.p>}" !!)
   ->.p
@@ -1983,7 +1993,7 @@
         %cell-check
       ~|  %cell-check
       =^  val  jyp  $(j val.j)
-      [[%3 val] [%atom %loobean %.n]^%$]
+      [[%3 val] [%atom %logical %.n]^%$]
     ::
         %compose
       ~|  %compose-p
@@ -2340,7 +2350,7 @@
       ==
     ::
         %compare
-      :_  [%atom %loobean %.n]^%$
+      :_  [%atom %logical %.n]^%$
       ?-    comp.j
           %'=='
         =+  [a a-jyp]=$(j a.j)
@@ -2665,7 +2675,7 @@
             %string       %ta
             %number       %ud
             %hexadecimal  %ux
-            %loobean      %f
+            %logical      %f
           ==
         p.p.arg
       ::
@@ -2727,7 +2737,7 @@
           %t    %string
           %ta   %string
           %tas  %string
-          %f    %loobean
+          %f    %logical
         ==
       =(~ q.t)
     ::
@@ -2819,7 +2829,7 @@
         %atom
       %-  crip
       ?-    ->-.jype
-        %loobean
+        %logical
       "{<;;(? +.nock)>}"
       ::
         %number

--- a/common/hoon/lib/jock.hoon
+++ b/common/hoon/lib/jock.hoon
@@ -30,14 +30,14 @@
       |=  txt=@
       ^-  *
       =/  jok  (jeam (cat 3 'import hoon;\0a' txt))
-      =+  [nok jyp]=(~(mint cj:~(. +> libs) [%atom %string %.n]^%$) jok)
+      =+  [nok jyp]=(~(mint cj:~(. +> libs) [%atom %chars %.n]^%$) jok)
       nok
     ::
     ++  jypist
       |=  txt=@
       ^-  jype
       =/  jok  (jeam (cat 3 'import hoon;\0a' txt))
-      =+  [nok jyp]=(~(mint cj:~(. +> libs) [%atom %string %.n]^%$) jok)
+      =+  [nok jyp]=(~(mint cj:~(. +> libs) [%atom %chars %.n]^%$) jok)
       jyp
     --
 =>
@@ -113,7 +113,7 @@
 +$  jnoun
   $+  jnoun
   $%  [%string p=tape]
-          [%path p=path]
+      [%path p=path]
   ==
 ::
 +$  token
@@ -544,7 +544,6 @@
       %logical
       %date
       %span
-      %path
   ==
 ::  Jype noun base types; corresponds to jnoun tags
 +$  jnoun-type
@@ -1857,7 +1856,7 @@
   ++  mint
     |=  j=jock
     ^-  [nock jype]
-    ?-    -.j
+    ?+    -.j  ~|("cj: unimplmented jock: {<-.j>}" !!)
         ^
       ~|  %pair-p
       =+  [p p-jyp]=$(j p.j)
@@ -2631,6 +2630,8 @@
     ::
         %fork      $(j p.p.j)
     ::
+        %noun      [%1 0]
+    ::
         %list      [%1 0]
     ::
         %set       [%1 0]
@@ -2672,10 +2673,17 @@
         ;;  hoon
         :+  ?:(q.p.arg %rock %sand)
           ?-  -<.p.arg
-            %string       %ta
+            %chars        %ta
             %number       %ud
-            %hexadecimal  %ux
+            %sint         %sd
+            %hex          %ux
+            %real         %rd
+            %real16       %rh
+            %real32       %rs
+            %real128      %rq
             %logical      %f
+            %date         %da
+            %span         %dr
           ==
         p.p.arg
       ::
@@ -2685,10 +2693,35 @@
         ~|  %limb
         ~
       ::
+          %noun
+        ::  What we call nouns are specific types.
+        ::  [%noun p=jnoun]
+        ?-    -.p.arg
+          ::  a string is simply a tape, (list @tD)
+            %string
+          ~|  %string
+          ;;  (list hoon)
+          :_  ~
+          :-  %knit
+          ^-  *
+          p.p.arg
+          ::  a path is a (list @t)
+            %path
+          ~|  %path
+          :_  ~
+          :-  %clsg
+          %+  turn
+            p.p.arg
+          |=  =cord
+          ^-  hoon
+          [%sand %t cord]
+        ==
+      ::
           %list
         ::  Lists are composed of a series of values, which we unpack.
         ::  [%list type=jype-leaf val=(list jock)]
         ~|  %list
+        ;;  (list hoon)
         :_  ~
         :-  %clsg
         %-  snip  :: spurious ~ from Jock representation
@@ -2732,12 +2765,20 @@
       ^-  jype-leaf
       :+  %atom
         ?+  p.t  ~|("cannot convert atom type {<p.t>} to jatom" !!)
+          %t    %chars
+          %ta   %chars
+          %tas  %chars
           %ud   %number
-          %ux   %hexadecimal
-          %t    %string
-          %ta   %string
-          %tas  %string
+          %sd   %sint
+          %ux   %hex
+          %x    %hex
+          %rd   %real
+          %rh   %real16
+          %rs   %real32
+          %rq   %real128
           %f    %logical
+          %da   %date
+          %dr   %span
         ==
       =(~ q.t)
     ::
@@ -2828,17 +2869,17 @@
     ::
         %atom
       %-  crip
-      ?-    ->-.jype
+      ?+    ->-.jype  "{<(* +.nock)>}"
         %logical
       "{<;;(? +.nock)>}"
       ::
         %number
       "{<;;(@ud +.nock)>}"
       ::
-        %hexadecimal
+        %hex
       "{<;;(@ux +.nock)>}"
       ::
-        %string
+        %chars
       "{<;;(@t +.nock)>}"
       ::
       ==

--- a/common/hoon/lib/jock.hoon
+++ b/common/hoon/lib/jock.hoon
@@ -191,6 +191,7 @@
         %compose  %loop  %defer
         %recur  %match  %switch  %eval  %with  %this
         %import  %as  %print
+        :: %for
     ==
   ::
   ++  tagged-symbol
@@ -224,14 +225,14 @@
   ++  number
     %+  stag  %number
     dem
-  ::  Signed numeric literal: -1234, +1_234 -> @sd
+  ::  Signed numeric literal: -1234, +1234 -> @sd
   ++  sint
     %+  stag  %sint
     ;~  pose
         (cook |=(n=@ud (new:si & n)) ;~(pfix lus dem:ag))
         (cook |=(n=@ud (new:si | n)) ;~(pfix hep dem:ag))
     ==
-    :: TODO switch to dep when fixed
+    :: TODO switch to dep when fixed for +1_234_678 support
   ::  Hexadecimal literal: 0xBA1A3F, 0xba1a3f -> @x
   ++  hex
     %+  stag  %hex
@@ -408,7 +409,7 @@
       :: [%impl]
       :: [%trait]
       :: [%union]
-      :: [%alias]
+      [%alias name=cord target=cord]
       [%class state=jype arms=(map term jock)]
       [%method type=jype body=jock]
       ::
@@ -622,7 +623,7 @@
   ^-  [jock (list token)]
   ?:  =(~ tokens)  ~|("expect inner-jock. token: ~" !!)
   ?:  ?|  (has-keyword -.tokens %object)
-          :: (has-keyword -.tokens %class)
+          (has-keyword -.tokens %alias)
           (has-keyword -.tokens %with)
           (has-keyword -.tokens %this)
           (has-keyword -.tokens %crash)
@@ -1031,6 +1032,17 @@
     :: %')' consumed by +match-pair-inner-jock
     [[%call [%lambda lambda] `arg] tokens]
   ::
+  ::  [%alias name=term target=term]
+      %alias
+    =/  name=cord
+      (got-name -.tokens)
+    =.  tokens  +.tokens
+    =/  target=cord
+      (got-name -.tokens)
+    =.  tokens  +.tokens
+    =-  ~&(- -)
+    [[%alias name target] tokens]
+  ::
   ::  [%class state=jype arms=(map term jock)]
     ::   %class
     :: =^  state  tokens
@@ -1143,8 +1155,8 @@
     :_  tokens
     [%compose p q]
   ::
-      %match
   :: [%match value=jock cases=(map jock jock) default=(unit jock)]
+      %match
     =^  value  tokens
       (match-inner-jock tokens)
     =^  pairs  tokens
@@ -1152,8 +1164,8 @@
     :_  tokens
     [%match value -.pairs +.pairs]
   ::
-      %switch
   :: [%cases value=jock cases=(map jock jock) default=(unit jock)]
+      %switch
     =^  value  tokens
       (match-inner-jock tokens)
     =^  pairs  tokens
@@ -1931,6 +1943,11 @@
         ~|  ['have:' val-jyp 'need:' type.j]
         !!
       [val val-jyp]
+    ::
+        %alias
+      ::  Look up the type being aliased in the current subject.
+      ~&  "alias not implemented yet"
+      ~|("cj: unimplemented alias: {<j>}" !!)
     ::
         %class
       ~|  %class

--- a/common/hoon/lib/jock.hoon
+++ b/common/hoon/lib/jock.hoon
@@ -1856,7 +1856,7 @@
   ++  mint
     |=  j=jock
     ^-  [nock jype]
-    ?+    -.j  ~|("cj: unimplmented jock: {<-.j>}" !!)
+    ?-    -.j  ::~|("cj: unimplemented jock: {<-.j>}" !!)
         ^
       ~|  %pair-p
       =+  [p p-jyp]=$(j p.j)
@@ -2542,9 +2542,16 @@
       ==
     ::
         %atom
+      ::  [%atom [type value] flag]
       ~|  [%atom +<+.j]
       :-  [%1 +<+.j]
       [^-(jype-leaf [%atom +<-.j +>.j]) %$]
+    ::
+        %noun
+      ::  [%noun [type value]]
+      ~|  [%noun +>.j]
+      :-  [%1 +>.j]
+      [^-(jype-leaf [%noun +<.j]) %$]
     ::
         %import
       ~|  %import
@@ -2708,6 +2715,7 @@
           ::  a path is a (list @t)
             %path
           ~|  %path
+          ~&  "here in path"
           :_  ~
           :-  %clsg
           %+  turn
@@ -2820,7 +2828,7 @@
         ~|((crip "hunt: can't match {<`@tas`-<.jype>}") !!)
       ::
         %atom
-      ?>  +.+.-.jype
+      ?>  ->+.jype  ::+.+.-.jype
       [%5 [%1 q.p.jype] %0 axis]
       ::
         %fork

--- a/common/hoon/lib/jock.hoon
+++ b/common/hoon/lib/jock.hoon
@@ -89,12 +89,12 @@
       %'('  %')'  %'{'  %'}'  %'['  %']'
       %'='  %'<'  %'>'  %'#'
       %'+'  %'-'  %'*'  %'/'  %'%'  %'_'
-      ::%'->' TODO decide if necessary or to do in two steps
+      %'->'
   ==
 ::
 +$  jatom
   $+  jatom
-  $~  [[%loobean p=%.n] q=%.n]
+  $~  [[%logical p=%.n] q=%.n]
   $:  $%  [%chars p=cord]
           [%string p=tape]
           [%number p=@ud]
@@ -104,7 +104,7 @@
           [%real16 p=@rh]
           [%real32 p=@rs]
           [%real128 p=@rq]
-          [%logical p=?]
+          [%logical p=?(%.y %.n)]
           [%date p=@da]
           [%span p=@dr]
           [%path p=path]
@@ -187,7 +187,7 @@
   ::  Double-quoted tape: "foo" -> (list @tD)
   ++  string
     %+  stag  %string
-    (cook crip (ifix [doq doq] (star ;~(less soq prn))))
+    (ifix [doq doq] (star ;~(less doq prn)))
   ::  Numeric literal: 1234, 1_234 -> @ud
   ++  number
     %+  stag  %number
@@ -196,8 +196,8 @@
   ++  sint
     %+  stag  %sint
     ;~  pose
-      (cook |=(n=@ud (new:si & n)) ;~(pfix lus dem:ag))
-      (cook |=(n=@ud (new:si | n)) ;~(pfix hep dem:ag))
+        (cook |=(n=@ud (new:si & n)) ;~(pfix lus dem:ag))
+        (cook |=(n=@ud (new:si | n)) ;~(pfix hep dem:ag))
     ==
     :: TODO switch to dep when fixed
   ::  Hexadecimal literal: 0xBA1A3F, 0xba1a3f -> @x
@@ -236,7 +236,28 @@
   ::  Span:  ~d15h23m45s -> @dr
   ++  span
     %+  stag  %span
-    crub:so
+    %+  cook
+      |=  [a=(list [p=?(%d %h %m %s) q=@]) b=(list @)]
+      =+  rop=`tarp`[0 0 0 0 b]
+      |-  ^-  @dr
+      ?~  a  (yule rop)
+      ?-  p.i.a
+        %d  $(a t.a, d.rop (add q.i.a d.rop))
+        %h  $(a t.a, h.rop (add q.i.a h.rop))
+        %m  $(a t.a, m.rop (add q.i.a m.rop))
+        %s  $(a t.a, s.rop (add q.i.a s.rop))
+      ==
+    ;~  plug
+      %+  most
+        dot
+      ;~  pose
+        ;~(pfix (just 'd') (stag %d dim:ag))
+        ;~(pfix (just 'h') (stag %h dim:ag))
+        ;~(pfix (just 'm') (stag %m dim:ag))
+        ;~(pfix (just 's') (stag %s dim:ag))
+      ==
+      ;~(pose ;~(pfix ;~(plug dot dot) (most dot qix:ab)) (easy ~))
+    ==
   ::  Path:  /foo/bar/baz -> path
   ++  jpath
     %+  stag  %path
@@ -256,6 +277,7 @@
         real16
         real32
         real128
+        logical
         date
         span
         jpath
@@ -310,15 +332,15 @@
       [%punctuator `jpunc`%'((']
     (stag %punctuator punctuator)
   ++  punctuator
-    :: ;~  pose
-    ::   (cold %'->' (jest '->'))   :: must come before solo '-'
-    %-  perk
-    :~  %'.'  %';'  %','  %':'  %'&'  %'$'
-        %'@'  %'?'  %'!'  :: XXX exclude %'((' which is a pseudo-punctuator
-        %'('  %')'  %'{'  %'}'  %'['  %']'
-        %'='  %'<'  %'>'  %'#'
-        %'+'  %'-'  %'*'  %'/'  %'%'  %'_'
-    ==
+    ;~  pose
+        (cold %'->' (jest '->'))   :: must come before solo '-'
+        %-  perk
+        :~  %'.'  %';'  %','  %':'  %'&'  %'$'
+            %'@'  %'?'  %'!'  :: XXX exclude %'((' which is a pseudo-punctuator
+            %'('  %')'  %'{'  %'}'  %'['  %']'
+            %'='  %'<'  %'>'  %'#'
+            %'+'  %'-'  %'*'  %'/'  %'%'  %'_'
+    ==  ==
   ::
   ::  The parser's precedence rules:
   ::  1.  Keywords

--- a/common/hoon/lib/jock.hoon
+++ b/common/hoon/lib/jock.hoon
@@ -58,12 +58,16 @@
   $?  %let
       %func
       %lambda
-      %class
+      %struct
+      %impl
+      %trait
+      %union
+      %alias
+      %object
       %if
       %else
       %crash
       %assert
-      %object
       %compose
       %loop
       %defer
@@ -85,15 +89,25 @@
       %'('  %')'  %'{'  %'}'  %'['  %']'
       %'='  %'<'  %'>'  %'#'
       %'+'  %'-'  %'*'  %'/'  %'%'  %'_'
+      ::%'->' TODO decide if necessary or to do in two steps
   ==
 ::
 +$  jatom
   $+  jatom
   $~  [[%loobean p=%.n] q=%.n]
-  $:  $%  [%string p=cord]
+  $:  $%  [%chars p=cord]
+          [%string p=tape]
           [%number p=@ud]
-          [%hexadecimal p=@ux]
-          [%loobean p=?]
+          [%sint p=@sd]
+          [%hex p=@x]
+          [%real p=@rd]
+          [%real16 p=@rh]
+          [%real32 p=@rs]
+          [%real128 p=@rq]
+          [%logical p=?]
+          [%date p=@da]
+          [%span p=@dr]
+          [%path p=path]
       ==
       q=?(%.y %.n)                  ::  constant flag
   ==
@@ -121,21 +135,135 @@
           ==
 ++  gav  (cold ~ (star ;~(pose val var gah)))
 ++  gae  ;~(pose gav (easy ~))
+::  '1_234_567' -> 0i1234567
+:: ++  dep  (ape:ag (bass 1.000 ;~(plug ted:ab (star ;~(pfix ;~(plug cab gay) tid:ab)))))
+++  dep  (ape:ag (bass 1.000 ;~(plug ted:ab (star ;~(pfix cab tid:ab)))))
+::
+++  roy
+  =/  moo
+    |=  a=tape
+    :-  (lent a)
+    (scan a (bass 10 (plus sid:ab)))
+  ;~  pose
+    ;~  plug
+      (easy %d)
+      ;~(pose (cold | hep) (cold & lus) (easy &))
+      ;~  plug  dim:ag
+        ;~  pose
+          ;~(pfix dot (cook moo (plus (shim '0' '9'))))
+          (easy [0 0])
+        ==
+        ;~  pose
+          ;~  pfix
+            (just 'e')
+            ;~(plug ;~(pose (cold | hep) (easy &)) dim:ag)
+          ==
+          (easy [& 0])
+        ==
+      ==
+    ==
+    ::
+    ;~  plug
+      (easy %i)
+      ;~  sfix
+        ;~(pose (cold | hep) (easy &))
+        (jest 'inf')
+      ==
+    ==
+    ::
+    ;~  plug
+      (easy %n)
+      (cold ~ (jest 'nan'))
+    ==
+  ==
 ::
 ++  tokenize
   =|  fun=?(%.y %.n)
   |%
-  ++  string             (stag %string (cook crip (ifix [soq soq] (star ;~(less soq prn)))))
-  ++  number             (stag %number dem:ag)
-  ++  hexadecimal        (stag %hexadecimal ;~(pfix (jest %'0x') hex))
-  ++  loobean
-    %+  stag  %loobean
-    ;~(pose (cold %.y (jest %true)) (cold %.n (jest %false)))
+  ::  Single-quoted cord: 'foo' -> @t
+  ++  chars
+    %+  stag  %chars
+    (cook crip (ifix [soq soq] (star ;~(less soq prn))))
+  ::  Double-quoted tape: "foo" -> (list @tD)
+  ++  string
+    %+  stag  %string
+    (cook crip (ifix [doq doq] (star ;~(less soq prn))))
+  ::  Numeric literal: 1234, 1_234 -> @ud
+  ++  number
+    %+  stag  %number
+    ;~(pose dep dem)
+  ::  Signed numeric literal: -1234, +1_234 -> @sd
+  ++  sint
+    %+  stag  %sint
+    ;~  pose
+      (cook |=(n=@ud (new:si & n)) ;~(pfix lus dem:ag))
+      (cook |=(n=@ud (new:si | n)) ;~(pfix hep dem:ag))
+    ==
+    :: TODO switch to dep when fixed
+  ::  Hexadecimal literal: 0xBA1A3F, 0xba1a3f -> @x
+  ++  hex
+    %+  stag  %hex
+    ;~(pfix (jest %'0x') ^hex)
+  ::  Real 64-bit float: 3.14, +3.14, -0.001 -> @rd
+  ++  real
+    %+  stag  %real
+    (cook ryld (cook royl-cell:so roy))
+  ::  Real 16-bit float: 3.14, +3.14, -0.001 -> @rh
+  ++  real16
+    %+  stag  %real16
+    (cook rylh (cook royl-cell:so roy))
+  ::  Real 32-bit float: 3.14, +3.14, -0.001 -> @rs
+  ++  real32
+    %+  stag  %real32
+    (cook ryls (cook royl-cell:so roy))
+  ::  Real 128-bit float: 3.14, +3.14, -0.001 -> @rq
+  ++  real128 
+    %+  stag  %real128
+    (cook rylq (cook royl-cell:so roy))
+  ::  Real 64-bit float alias
+  ++  real64  real
+  ::  Logical loobean:  %true, %false -> ?
+  ++  logical
+    %+  stag  %logical
+    ;~  pose
+        (cold %.y (jest %true))
+        (cold %.n (jest %false))
+    ==
+  ::  Date:  @2026.1.1..12.0.0..ffff -> @da
+  ++  date
+    %+  stag  %date
+    ;~(pfix pat (cook year when:so))
+  ::  Span:  ~d15h23m45s -> @dr
+  ++  span
+    %+  stag  %span
+    crub:so
+  ::  Path:  /foo/bar/baz -> path
+  ++  jpath
+    %+  stag  %path
+    stap
   ::
-  ++  tagged-literal     (stag %literal (hart literal %.n))
-  ++  literal            ;~(pose loobean hexadecimal number string)
-  ++  tagged-symbol      (stag %literal (hart symbol %.y))
-  ++  symbol             ;~(pfix cen literal)
+  ++  tagged-literal
+    %+  stag  %literal
+    (hart literal %.n)
+  ++  literal
+    ;~  pose
+        chars
+        string
+        number
+        sint
+        hex
+        real
+        real16
+        real32
+        real128
+        date
+        span
+        jpath
+    ==
+  ++  tagged-symbol
+    %+  stag  %literal
+    (hart symbol %.y)
+  ++  symbol          ;~(pfix cen literal)
   ::  add a suffix label
   ++  hart
     |*  [sef=rule gob=*]
@@ -150,37 +278,40 @@
   ::  the goal is to parse a function call into the pseudo-punctuator '(('.
   ::  This only happens if there is a name or type immediately preceding '(',
   ::  e.g. foo(bar)  ->  'foo' '((' 'bar' ')'
-  ++  tagged-name        (stag %name name)                :: [%name term]
-  ++  name               snek                             :: term with _
-  ++  snek               %+  cook
-                           |=(a=tape (rap 3 ^-((list @) a)))
-                         ;~(plug low (star ;~(pose nud low cab)))
+  ++  tagged-name       (stag %name sym)
   ::
-  ++  tagged-type        (stag %type type)                :: [%type 'Cord']
-  ++  type               aul                              :: Cord
-  ++  aul                %+  cook                         :: Ulll
-                             |=(a=tape (rap 3 ^-((list @) a)))
-                         ;~(plug hig (star low))
+  ++  tagged-type
+    %+  stag  %type
+    nik
+  ::  PascalCase identifier (type names)
+  ++  nik
+    %+  cook
+      |=(a=tape (rap 3 ^-((list @) a)))
+    ;~(plug hig (star ;~(pose hig low)))
   ::
   ++  tagged-keyword     (stag %keyword keyword)
   ++  keyword
     %-  perk
-    :~  %let  %func  %lambda  %class
-        %if  %else  %crash  %assert
-        %object  %compose  %loop  %defer
+    :~  %let  %func  %lambda
+        %struct  %impl  %trait  %union  %alias
+        %object  %if  %else  %crash  %assert
+        %compose  %loop  %defer
         %recur  %match  %switch  %eval  %with  %this
         %import  %as  %print
     ==
   ::
-  ++  tagged-punctuator  %+  cook
-                           |=  =token
-                           ^-  ^token
-                           ?.  &(fun =([%punctuator %'('] token))
-                             token
-                          ::  =.  fun  %.n
-                           [%punctuator `jpunc`%'((']
-                         (stag %punctuator punctuator)
+  ++  tagged-punctuator
+    %+  cook
+      |=  =token
+      ^-  ^token
+      ?.  &(fun =([%punctuator %'('] token))
+        token
+    ::  =.  fun  %.n
+      [%punctuator `jpunc`%'((']
+    (stag %punctuator punctuator)
   ++  punctuator
+    :: ;~  pose
+    ::   (cold %'->' (jest '->'))   :: must come before solo '-'
     %-  perk
     :~  %'.'  %';'  %','  %':'  %'&'  %'$'
         %'@'  %'?'  %'!'  :: XXX exclude %'((' which is a pseudo-punctuator

--- a/common/hoon/lib/jock.hoon
+++ b/common/hoon/lib/jock.hoon
@@ -135,9 +135,6 @@
           ==
 ++  gav  (cold ~ (star ;~(pose val var gah)))
 ++  gae  ;~(pose gav (easy ~))
-::  '1_234_567' -> 0i1234567
-:: ++  dep  (ape:ag (bass 1.000 ;~(plug ted:ab (star ;~(pfix ;~(plug cab gay) tid:ab)))))
-++  dep  (ape:ag (bass 1.000 ;~(plug ted:ab (star ;~(pfix cab tid:ab)))))
 ::
 ++  roy
   =/  moo
@@ -188,10 +185,10 @@
   ++  string
     %+  stag  %string
     (ifix [doq doq] (star ;~(less doq prn)))
-  ::  Numeric literal: 1234, 1_234 -> @ud
+  ::  Numeric literal: 1234 -> @ud
   ++  number
     %+  stag  %number
-    ;~(pose dep dem)
+    dem
   ::  Signed numeric literal: -1234, +1_234 -> @sd
   ++  sint
     %+  stag  %sint

--- a/common/hoon/lib/jock.hoon
+++ b/common/hoon/lib/jock.hoon
@@ -96,7 +96,6 @@
   $+  jatom
   $~  [[%logical p=%.n] q=%.n]
   $:  $%  [%chars p=cord]
-          [%string p=tape]
           [%number p=@ud]
           [%sint p=@sd]
           [%hex p=@x]
@@ -107,16 +106,21 @@
           [%logical p=?(%.y %.n)]
           [%date p=@da]
           [%span p=@dr]
-          [%path p=path]
       ==
       q=?(%.y %.n)                  ::  constant flag
+  ==
+::
++$  jnoun
+  $+  jnoun
+  $%  [%string p=tape]
+          [%path p=path]
   ==
 ::
 +$  token
   $+  token
   $%  [%keyword keyword]
       [%punctuator jpunc]
-      [%literal jatom]
+      [%literal ?([%atom jatom] [%noun jnoun])]
       [%name cord]
       [%type cord]
   ==
@@ -177,14 +181,45 @@
 ++  tokenize
   =|  fun=?(%.y %.n)
   |%
+  ::
+  ++  tagged-keyword     (stag %keyword keyword)
+  ++  keyword
+    %-  perk
+    :~  %let  %func  %lambda
+        %struct  %impl  %trait  %union  %alias
+        %object  %if  %else  %crash  %assert
+        %compose  %loop  %defer
+        %recur  %match  %switch  %eval  %with  %this
+        %import  %as  %print
+    ==
+  ::
+  ++  tagged-symbol
+    %+  stag  %literal
+    %+  stag  %atom
+    (hart ;~(pfix cen literal-atom) %.y)
+  ::
+  ++  tagged-literal-atom
+    %+  stag  %literal
+    %+  stag  %atom
+    (hart literal-atom %.n)
+  ++  literal-atom
+    ;~  pose
+        chars
+        number
+        sint
+        hex
+        real
+        real16
+        real32
+        real128
+        logical
+        date
+        span
+    ==
   ::  Single-quoted cord: 'foo' -> @t
   ++  chars
     %+  stag  %chars
     (cook crip (ifix [soq soq] (star ;~(less soq prn))))
-  ::  Double-quoted tape: "foo" -> (list @tD)
-  ++  string
-    %+  stag  %string
-    (ifix [doq doq] (star ;~(less doq prn)))
   ::  Numeric literal: 1234 -> @ud
   ++  number
     %+  stag  %number
@@ -255,34 +290,21 @@
       ==
       ;~(pose ;~(pfix ;~(plug dot dot) (most dot qix:ab)) (easy ~))
     ==
+  ++  tagged-literal-noun
+    %+  stag  %literal
+    %+  stag  %noun
+    ;~  pose
+        string
+        jpath
+    ==
+  ::  Double-quoted tape: "foo" -> (list @tD)
+  ++  string
+    %+  stag  %string
+    (ifix [doq doq] (star ;~(less doq prn)))
   ::  Path:  /foo/bar/baz -> path
   ++  jpath
     %+  stag  %path
     stap
-  ::
-  ++  tagged-literal
-    %+  stag  %literal
-    (hart literal %.n)
-  ++  literal
-    ;~  pose
-        chars
-        string
-        number
-        sint
-        hex
-        real
-        real16
-        real32
-        real128
-        logical
-        date
-        span
-        jpath
-    ==
-  ++  tagged-symbol
-    %+  stag  %literal
-    (hart symbol %.y)
-  ++  symbol          ;~(pfix cen literal)
   ::  add a suffix label
   ++  hart
     |*  [sef=rule gob=*]
@@ -307,17 +329,6 @@
     %+  cook
       |=(a=tape (rap 3 ^-((list @) a)))
     ;~(plug hig (star ;~(pose hig low)))
-  ::
-  ++  tagged-keyword     (stag %keyword keyword)
-  ++  keyword
-    %-  perk
-    :~  %let  %func  %lambda
-        %struct  %impl  %trait  %union  %alias
-        %object  %if  %else  %crash  %assert
-        %compose  %loop  %defer
-        %recur  %match  %switch  %eval  %with  %this
-        %import  %as  %print
-    ==
   ::
   ++  tagged-punctuator
     %+  cook
@@ -351,7 +362,8 @@
     ;~  pose
         (knee *(list token) |.(~+(;~(plug tagged-keyword ;~(pfix gav tokens(fun %.n))))))
         (knee *(list token) |.(~+(;~(plug tagged-symbol ;~(pfix gav tokens(fun %.n))))))
-        (knee *(list token) |.(~+(;~(plug tagged-literal ;~(pfix gav tokens(fun %.n))))))
+        (knee *(list token) |.(~+(;~(plug tagged-literal-atom ;~(pfix gav tokens(fun %.n))))))
+        (knee *(list token) |.(~+(;~(plug tagged-literal-noun ;~(pfix gav tokens(fun %.n))))))
         (knee *(list token) |.(~+(;~(plug tagged-name ;~(pfix gav tokens(fun %.y))))))
         (knee *(list token) |.(~+(;~(plug tagged-punctuator ;~(pfix gav tokens(fun %.n))))))
         (knee *(list token) |.(~+(;~(plug tagged-type ;~(pfix gav tokens(fun %.y))))))
@@ -389,32 +401,40 @@
   $+  jock
   $^  [p=jock q=jock]
   $%  [%let type=jype val=jock next=jock]
+      [%edit limb=(list jlimb) val=jock next=jock]
       [%func type=jype body=jock next=jock]
+      [%lambda p=lambda]
+      :: [%struct]
+      :: [%impl]
+      :: [%trait]
+      :: [%union]
+      :: [%alias]
       [%class state=jype arms=(map term jock)]
       [%method type=jype body=jock]
-      [%edit limb=(list jlimb) val=jock next=jock]
-      [%increment val=jock]
-      [%cell-check val=jock]
-      [%compose p=jock q=jock]
+      ::
       [%object name=term p=(map term jock) q=(unit jock)]
-      [%eval p=jock q=jock]
-      [%loop next=jock]
-      [%defer next=jock]
       if-expression
       [%assert cond=jock then=jock]
+      [%compose p=jock q=jock]
+      [%loop next=jock]
+      [%defer next=jock]
       [%match value=jock cases=(map jock jock) default=(unit jock)]
       [%cases value=jock cases=(map jock jock) default=(unit jock)]
+      [%eval p=jock q=jock]
+      [%print body=?([%jock jock]) next=jock]
+      ::
+      [%operator op=operator a=jock b=(unit jock)]
+      [%increment val=jock]
+      [%cell-check val=jock]
       [%call func=jock arg=(unit jock)]
       [%compare comp=comparator a=jock b=jock]
-      [%operator op=operator a=jock b=(unit jock)]
-      [%lambda p=lambda]
       [%limb p=(list jlimb)]
       [%atom p=jatom]
+      [%noun p=jnoun]
       [%list type=jype-leaf val=(list jock)]
       [%set type=jype-leaf val=(set jock)]
       [%import name=jype next=jock]
-      [%print body=?([%jock jock]) next=jock]
-      [%crash ~]
+      [%crash ~]  :: keep last for Hoon type bunting
   ==
 ::
 +$  if-expression
@@ -511,10 +531,18 @@
 ::  Jype atom base types; corresponds to jatom tags
 +$  jatom-type
   $+  jatom-type
-  $?  %string
+  $?  %chars
       %number
-      %hexadecimal
-      %loobean
+      %sint
+      %hex
+      %real
+      %real16
+      %real32
+      %real128
+      %logical
+      %date
+      %span
+      %path
   ==
 ::  Jype core executable, either a direct lambda or a regular core
 +$  core-body  (each lambda-argument (map term jype))
@@ -587,7 +615,7 @@
   ^-  [jock (list token)]
   ?:  =(~ tokens)  ~|("expect inner-jock. token: ~" !!)
   ?:  ?|  (has-keyword -.tokens %object)
-          (has-keyword -.tokens %class)
+          :: (has-keyword -.tokens %class)
           (has-keyword -.tokens %with)
           (has-keyword -.tokens %this)
           (has-keyword -.tokens %crash)
@@ -890,6 +918,7 @@
   ?:  !=(%type -<.tokens)
     ~|("expect type. token: {<-.tokens>}" !!)
   =/  type=cord
+    ::  Short-circuits on built-in container types
     ?:  =([%type 'List'] -.tokens)  %list
     ?:  =([%type 'Set'] -.tokens)   %set
     :: ?:  =([%type 'Map'] -.tokens)   %map
@@ -897,12 +926,20 @@
     ->.tokens
   =/  nom  (get-name -.tokens)
   ?~  nom  ~|("expect name. token: {<-.tokens>}" !!)
-  ::  Short-circuit on built-in primitive types
-  ?:  =('Atom' u.nom)    [[%atom %number %.n]^u.nom +.tokens]
-  ?:  =('Uint' u.nom)    [[%atom %number %.n]^u.nom +.tokens]
-  ?:  =('Uhex' u.nom)    [[%atom %hexadecimal %.n]^u.nom +.tokens]
-  ?:  =('String' u.nom)  [[%atom %string %.n]^u.nom +.tokens]
-  ?:  =('Loob' u.nom)    [[%atom %loobean %.n]^u.nom +.tokens]
+  ::  Short-circuits on built-in primitive types
+  ?:  =('Atom' u.nom)     [[%atom %number %.n]^u.nom +.tokens]
+  ?:  =('Uint' u.nom)     [[%atom %number %.n]^u.nom +.tokens]
+  ?:  =('Int' u.nom)      [[%atom %sint %.n]^u.nom +.tokens]
+  ?:  =('Hex' u.nom)      [[%atom %hex %.n]^u.nom +.tokens]
+  ?:  =('Real' u.nom)     [[%atom %real %.n]^u.nom +.tokens]
+  ?:  =('Real16' u.nom)   [[%atom %real16 %.n]^u.nom +.tokens]
+  ?:  =('Real32' u.nom)   [[%atom %real32 %.n]^u.nom +.tokens]
+  ?:  =('Real128' u.nom)  [[%atom %real128 %.n]^u.nom +.tokens]
+  ?:  =('Logical' u.nom)  [[%atom %logical %.n]^u.nom +.tokens]
+  ?:  =('Date' u.nom)     [[%atom %date %.n]^u.nom +.tokens]
+  ?:  =('Span' u.nom)     [[%atom %span %.n]^u.nom +.tokens]
+  ?:  =('String' u.nom)   [[%noun %string]^u.nom +.tokens]
+  ?:  =('Path' u.nom)     [[%noun %path]^u.nom +.tokens]
   ::
   =.  tokens  +.tokens
   ?.  =([%punctuator %'(('] -.tokens)
@@ -988,54 +1025,54 @@
     [[%call [%lambda lambda] `arg] tokens]
   ::
   ::  [%class state=jype arms=(map term jock)]
-      %class
-    =^  state  tokens
-      (match-jype tokens)
-    ::  mask out reserved types
-    ?:  =([%type 'List'] name.state)  ~|('Shadowing reserved type List is not allowed.' !!)
-    ?:  =([%type 'Set'] name.state)   ~|('Shadowing reserved type Set is not allowed.' !!)
-    :: ?:  =([%type 'Map'] name.state)   ~|('Shadowing reserved type Map is not allowed.' !!)
-    ?>  (got-punctuator -.tokens %'{')
-    =|  arms=(map term jock)
-    =.  tokens  +.tokens
-    =^  arms  tokens
-      |-
-      ?:  (has-punctuator -.tokens %'}')
-        [arms +.tokens]
-      ::  Retrieve the name of the method.
-      =^  type  tokens
-        (match-jype tokens)
-      ::  Gather the arguments and output type.
-      =^  inp  tokens
-        ?>  (got-punctuator -.tokens %'((')
-        =^  r=(pair jype (unit jype))  tokens
-          =^  jyp-one  tokens  (match-jype +.tokens)
-          ?:  (has-punctuator -.tokens %')')
-            ::  short-circuit if single element in cell
-            [[jyp-one ~] tokens]
-          =^  jyp-two  tokens  (match-jype tokens)
-          ::  TODO: support implicit right-association  (what's a good test case?)
-          [[jyp-one `jyp-two] tokens]
-        [?~(q.r `jype`p.r `jype`[[p.r u.q.r] %$]) tokens]
-      ?>  (got-punctuator -.tokens %')')
-      =.  tokens  +.tokens
-      ?>  (got-punctuator -.tokens %'-')
-      ?>  (got-punctuator +<.tokens %'>')
-      =.  tokens  +>.tokens
-      =^  out  tokens
-        (match-jype tokens)
-      =.  type
-        :-  [%core [%& [`inp out]] ~]
-        name.type
-      ::  Retrieve the body of the method.
-      =^  body  tokens
-        (match-block [tokens %'{' %'}'] match-jock)
-      =.  body
-        :-  %lambda
-        [[`inp out] body ~]
-      $(arms (~(put by arms) name.type [%method type body]))
-    :_  tokens
-    [%class state=state arms=arms]
+    ::   %class
+    :: =^  state  tokens
+    ::   (match-jype tokens)
+    :: ::  mask out reserved types
+    :: ?:  =([%type 'List'] name.state)  ~|('Shadowing reserved type List is not allowed.' !!)
+    :: ?:  =([%type 'Set'] name.state)   ~|('Shadowing reserved type Set is not allowed.' !!)
+    :: :: ?:  =([%type 'Map'] name.state)   ~|('Shadowing reserved type Map is not allowed.' !!)
+    :: ?>  (got-punctuator -.tokens %'{')
+    :: =|  arms=(map term jock)
+    :: =.  tokens  +.tokens
+    :: =^  arms  tokens
+    ::   |-
+    ::   ?:  (has-punctuator -.tokens %'}')
+    ::     [arms +.tokens]
+    ::   ::  Retrieve the name of the method.
+    ::   =^  type  tokens
+    ::     (match-jype tokens)
+    ::   ::  Gather the arguments and output type.
+    ::   =^  inp  tokens
+    ::     ?>  (got-punctuator -.tokens %'((')
+    ::     =^  r=(pair jype (unit jype))  tokens
+    ::       =^  jyp-one  tokens  (match-jype +.tokens)
+    ::       ?:  (has-punctuator -.tokens %')')
+    ::         ::  short-circuit if single element in cell
+    ::         [[jyp-one ~] tokens]
+    ::       =^  jyp-two  tokens  (match-jype tokens)
+    ::       ::  TODO: support implicit right-association  (what's a good test case?)
+    ::       [[jyp-one `jyp-two] tokens]
+    ::     [?~(q.r `jype`p.r `jype`[[p.r u.q.r] %$]) tokens]
+    ::   ?>  (got-punctuator -.tokens %')')
+    ::   =.  tokens  +.tokens
+    ::   ?>  (got-punctuator -.tokens %'-')
+    ::   ?>  (got-punctuator +<.tokens %'>')
+    ::   =.  tokens  +>.tokens
+    ::   =^  out  tokens
+    ::     (match-jype tokens)
+    ::   =.  type
+    ::     :-  [%core [%& [`inp out]] ~]
+    ::     name.type
+    ::   ::  Retrieve the body of the method.
+    ::   =^  body  tokens
+    ::     (match-block [tokens %'{' %'}'] match-jock)
+    ::   =.  body
+    ::     :-  %lambda
+    ::     [[`inp out] body ~]
+    ::   $(arms (~(put by arms) name.type [%method type body]))
+    :: :_  tokens
+    :: [%class state=state arms=arms]
   ::
   ::  if (a < b) { +(a) } else { +(b) }
   ::  [%if cond=jock then=jock after-if=after-if-expression]
@@ -1368,10 +1405,12 @@
 ::
 ++  match-literal
   |=  =tokens
-  ^-  [[%atom jatom] (list token)]
+  ^-  [?([%atom jatom] [%noun jnoun]) (list token)]
   ?:  =(~ tokens)  ~|("expect literal. token: ~" !!)
   ?.  ?=(%literal -<.tokens)
     ~|("expect literal. token: {<-<.tokens>}" !!)
+  ?:  ?=(%noun -<.tokens)
+    [[%noun -<.tokens] +.tokens]
   [[%atom ->.tokens] +.tokens]
 ::
 ++  match-name

--- a/docs/JOCK_COMPLETION_SPEC.md
+++ b/docs/JOCK_COMPLETION_SPEC.md
@@ -1,0 +1,894 @@
+# Jock Language Completion Specification
+## Mission: Make Nock Programming Accessible & Production-Ready
+
+**Status:** Alpha → Beta → Production
+**Target:** NockApp kernels, Urbit Gall agents, Nockchain applications
+**Repository:** github.com/zorp-corp/jock-lang (fork: github.com/sigilante/jock-lang)
+
+---
+
+## Executive Summary
+
+Jock is a subject-oriented, statically-typed functional language targeting Nock ISA. Current state: functional alpha with ad hoc type system. Goal: production-ready language with rigorous type system, full NockApp/Gall compatibility, and developer-friendly tooling.
+
+**Critical Path:**
+1. Type system overhaul (Beta spec → implementation)
+2. NockApp kernel interface completion
+3. Gall agent primitives
+4. Compiler optimization (sKa, jet matching)
+5. Developer tooling (LSP, debugger, package manager)
+
+---
+
+## Current State Assessment
+
+### What Works (Alpha)
+- Basic compiler pipeline: Jock → AST → Nock
+- Core language features: functions, objects, control flow
+- Hoon FFI (limited)
+- Basic types: atoms, cells, lists, sets
+- NockApp integration (via hoonc)
+- Test framework (jockt)
+
+### What's Broken/Missing
+- **Type system**: ad hoc, no traits, weak inference
+- **Standard library**: minimal, no Path/Wire native support
+- **NockApp interface**: incomplete kernel primitives
+- **Gall integration**: no agent support
+- **Tooling**: no LSP, limited debugging, no package manager
+- **Documentation**: incomplete, no design rationale docs
+- **Performance**: naive compilation, no sKa optimization
+
+---
+
+## Phase 1: Type System Overhaul (Beta → Implementation)
+
+### 1.1 Core Type System Components
+
+#### Structs
+```jock
+// Product types with named fields
+struct Point {
+  x: Real
+  y: Real
+}
+
+// Single-field newtypes (nominal wrappers)
+struct UserId(Atom)  // opaque, requires explicit cast
+
+// Transparent aliases
+alias Path = List<Chars>  // no cast needed
+```
+
+**Implementation Requirements:**
+- Parse struct definitions into AST nodes
+- Generate Nock core with appropriate battery/sample layout
+- Track field names and types in compilation environment
+- Support structural equality checking
+- Compile-time name resolution for fields
+
+**Nock Compilation Strategy:**
+- Struct → Door (core with sample)
+- Fields → Sample slots at computed axes
+- Methods → Battery arms
+- Constructor → Gate that produces core instance
+
+#### Traits
+```jock
+trait Arithmetic {
+  add(self, other: Self) -> Self
+  neg(self) -> Self
+}
+
+impl Arithmetic for Vec2 {
+  add(self, other: Self) -> Self {
+    Vec2(self.x + other.x, self.y + other.y)
+  }
+  neg(self) -> Self {
+    Vec2(-self.x, -self.y)
+  }
+}
+```
+
+**Implementation Requirements:**
+- Trait definition parsing and validation
+- Impl block compilation to Nock cores
+- Method resolution via subject tree walking
+- Trait bounds checking at compile time
+- Monomorphization (no dynamic dispatch)
+
+**Critical Design Decision:**
+Use `class` keyword instead of `impl` to manage subject scope:
+```jock
+class Point(List<Chars>) {
+  head(self) -> ?Chars { /* ... */ }
+  tail(self) -> Path { /* ... */ }
+  
+  // Nested impl for specific traits
+  concat impl List {
+    /* ... */
+  }
+}
+```
+
+**Subject-Oriented Method Resolution:**
+1. Walk subject tree (axis-by-axis)
+2. Find arm named `method` where target type = `T`
+3. Emit Nock: slot access + slam
+4. Name collisions: compile error (v1), later add `^` skip syntax
+
+#### Unions (Sum Types)
+```jock
+union Result {
+  case ok(value: Atom)
+  case err(code: Atom, msg: Chars)
+}
+```
+
+**Implementation Requirements:**
+- Head-tagged cells: `[%ok value]`, `[%err code msg]`
+- Pattern matching via `switch`/`match` (following `?+` pattern)
+- Exhaustiveness checking
+- No generics on unions for v1
+
+#### Generics
+```jock
+func first<T>(xs: List<T>) -> ?T {
+  switch xs {
+    [] -> ~
+    [head, ..tail] -> [~ head]
+  }
+}
+
+let x = first([1 2 3])  // T = Atom inferred
+let y = first([] as List<Atom>)  // T = Atom explicit
+```
+
+**Implementation Requirements:**
+- Type parameter binding at call site
+- Monomorphization (generate separate Nock for each concrete type)
+- Empty collection annotation requirement
+- Forward inference in function bodies
+- No runtime polymorphism
+
+### 1.2 Advanced Type Features
+
+#### Option Chaining
+```jock
+e: T       → e.f: U
+e: ?T      → e?.f: ?U
+e: ??T     → e?.f: ???U  // no flattening
+e: ?T, d:T → e ?? d: T   // default
+e: ?T      → e!: T       // unwrap-or-crash
+```
+
+**Implementation Strategy:**
+- Compile-time tracking of option depth
+- Nock compilation: test for `~`, branch accordingly
+- `!` operator: crash if null (Nock `[0 0]`)
+- `??` operator: test left, return left if non-null, else right
+
+#### Casting
+| Syntax | Compile-time | Runtime | Use |
+|--------|-------------|---------|-----|
+| `as` | structural check | no | same-shape nominal conversion |
+| `as?` | target known | mold check | returns `?T`, safe narrowing |
+| `as!` | target known | mold check | returns `T`, crash on fail |
+
+**Implementation Requirements:**
+- Structural cast: ignore field names, check shape
+- `as?`: runtime mold check (Hoon `;;` semantics), wrap in unit
+- `as!`: runtime mold check, crash if fail
+- All casts compile to Nock with appropriate type assertions
+
+### 1.3 Type Inference Rules
+| Context | Inference |
+|---------|-----------|
+| Function params | Explicit required |
+| Function return | Explicit required |
+| Lambda params | Explicit required |
+| Lambda return | Explicit required |
+| `let` binding | Inferred from RHS, or explicit |
+| Generic type params | Inferred from arguments at call site |
+| Empty collections | Explicit annotation required |
+| Mixed numeric literals | Unify to supertype |
+| Binary ops across types | Determined by operator's trait impl |
+
+**Implementation Strategy:**
+- Hindley-Milner-style inference for `let` bindings
+- Explicit annotations everywhere else (pragmatic approach)
+- Type errors: clear messages with suggested fixes
+
+---
+
+## Phase 2: NockApp Kernel Interface
+
+### 2.1 Kernel Structure Requirements
+
+**Standard Kernel Arms (Fixed Axes):**
+- `+4` / `+load`: Load/upgrade kernel state
+- `+10` / `+wish`: Evaluate Hoon expressions (optional)
+- `+22` / `+peek`: Read-only state access (scry)
+- `+23` / `+poke`: State-altering requests
+
+**Jock Implementation:**
+```jock
+class Kernel(state: AppState) {
+  // +load: upgrade handler
+  load(old: Noun) -> AppState {
+    // migration logic
+    old as! AppState
+  }
+  
+  // +wish: Hoon eval (can crash if not needed)
+  wish(expr: Noun) -> Noun {
+    crash("wish not implemented")
+  }
+  
+  // +peek: read-only queries
+  peek(path: Path) -> ?(?(Noun)) {
+    switch path {
+      /state/version -> [~ ~ version]
+      /state/data -> [~ ~ state.data]
+      _ -> [~ ~]  // not found
+    }
+  }
+  
+  // +poke: state mutations
+  poke(cause: Noun) -> (List<Effect>, AppState) {
+    let (effects, new_state) = process_cause(state, cause);
+    (effects, new_state)
+  }
+}
+```
+
+**Compilation Strategy:**
+- Generate door with sample = state
+- Battery arms at correct axes (use Hoon `++set` ordering)
+- Compile each arm to Nock formula
+- Ensure type-correct returns
+
+### 2.2 Essential NockApp Types
+
+From Beta spec, implement these natively:
+```jock
+alias Tang = List<Chars>
+alias Term = Chars
+
+struct Goof {
+  mote: Term
+  tang: Tang
+}
+
+alias Wire = Path
+
+struct Input {
+  eny: Uint      // entropy
+  our: Hex       // ship identity
+  now: Date      // current time
+  cause: Noun    // arbitrary cause data
+}
+
+struct Ovum {
+  wire: Wire
+  input: Input
+}
+
+struct Crud {
+  goof: Goof
+  input: Input
+}
+```
+
+**Path Native Syntax (Already Implemented in Beta):**
+```jock
+let p = /foo/bar/(segment)/baz
+let q = /
+let r = /users/(user-id as Chars)/profile
+```
+
+**Implementation Requirements:**
+- Parser support for `/foo/bar` syntax → `List<Chars>`
+- Compile to standard Hoon path representation
+- Interpolation support: `/(variable)` embeds value
+- Type checking: ensure interpolated values are `Chars`-compatible
+
+---
+
+## Phase 3: Urbit Gall Integration
+
+### 3.1 Gall Agent Primitives
+
+**Agent Arms (Beyond Kernel):**
+```jock
+class GallAgent(state: AgentState) {
+  // Kernel interface
+  load(old: Noun) -> AgentState { /* ... */ }
+  peek(path: Path) -> ?(?(Noun)) { /* ... */ }
+  poke(cause: Noun) -> (List<Effect>, AgentState) { /* ... */ }
+  
+  // Gall-specific
+  on_init() -> (List<Effect>, AgentState) {
+    // agent initialization
+    ([/* cards */], initial_state)
+  }
+  
+  on_watch(path: Path) -> (List<Effect>, AgentState) {
+    // subscription handling
+    ([/* initial facts */], state)
+  }
+  
+  on_leave(path: Path) -> (List<Effect>, AgentState) {
+    // unsubscription handling
+    ([], state)
+  }
+  
+  on_agent(wire: Wire, sign: Sign) -> (List<Effect>, AgentState) {
+    // agent communication
+    match sign {
+      poke_ack -> ([], state)
+      watch_ack -> ([], state)
+      kick -> ([], state)
+      fact -> {
+        // process fact
+        ([], new_state)
+      }
+    }
+  }
+  
+  on_arvo(wire: Wire, sign: ArvoSign) -> (List<Effect>, AgentState) {
+    // Arvo vane interaction
+    ([], state)
+  }
+  
+  on_fail(term: Term, tang: Tang) -> (List<Effect>, AgentState) {
+    // error handling
+    ([], state)
+  }
+}
+```
+
+### 3.2 Effect/Card System
+
+**Basic Card Types:**
+```jock
+union Card {
+  case poke(ship: Ship, agent: Term, mark: Mark, noun: Noun)
+  case watch(ship: Ship, agent: Term, path: Path)
+  case leave(ship: Ship, agent: Term)
+  case give(path: Path, mark: Mark, noun: Noun)
+  case pass(wire: Wire, note: Note)
+}
+
+union Note {
+  case behn(BehnNote)  // timer
+  case eyre(EyreNote)  // HTTP
+  case gall(GallNote)  // agent
+  case clay(ClayNote)  // filesystem
+}
+```
+
+**Implementation Strategy:**
+- Cards compile to standard Urbit card format
+- Type checking ensures correct structure
+- Helper functions for common patterns
+
+---
+
+## Phase 4: Compiler Optimization
+
+### 4.1 Subject Knowledge Analysis (sKa)
+
+**Problem:** Naive compilation produces verbose Nock with excessive cell allocation.
+
+**Solution:** Track known subject structure to optimize slot access.
+
+**Implementation:**
+1. Build subject type during compilation
+2. Compute axes statically whenever possible
+3. Eliminate redundant subject operations
+4. Fold constant expressions
+
+**Example Optimization:**
+```jock
+let x = 42;
+let y = x + 1;
+y * 2
+```
+
+Naive:
+```nock
+[8 [1 42] 8 [7 [0 2] 4 0 1] 7 [0 2] [4 4 0 1]]
+```
+
+Optimized (with sKa):
+```nock
+[1 86]  // constant fold: (42 + 1) * 2 = 86
+```
+
+### 4.2 Jet Matching
+
+**Problem:** Arithmetic operations beyond increment are slow in Nock.
+
+**Solution:** Emit Nock patterns that match standard jets.
+
+**Standard Jets to Target:**
+- `add`, `sub`, `mul`, `div`, `mod` (arithmetic)
+- `lent`, `snag`, `weld` (lists)
+- `turn`, `roll`, `fold` (higher-order)
+- String operations
+
+**Implementation Strategy:**
+1. Maintain jet hint database
+2. Recognize common patterns in AST
+3. Emit Nock with jet hints (opcode 11)
+4. Fallback to pure Nock if jet unavailable
+
+---
+
+## Phase 5: Developer Tooling
+
+### 5.1 Language Server Protocol (LSP)
+
+**Essential Features:**
+- Syntax highlighting
+- Error diagnostics (inline)
+- Go-to-definition
+- Auto-completion (context-aware)
+- Hover documentation
+- Rename refactoring
+
+**Implementation Strategy:**
+- Separate LSP server binary
+- Reuse parser/type checker from jockc
+- Incremental compilation for responsiveness
+- VSCode extension as reference implementation
+
+### 5.2 Debugger
+
+**Features:**
+- Breakpoints in Jock code
+- Step through execution
+- Inspect subject structure
+- View Nock trace
+- Time-travel debugging (replay)
+
+**Implementation Strategy:**
+- Instrument compiled Nock with debug hints
+- Build debugger on top of NockVM
+- Interactive REPL with inspection
+- Integration with jockc
+
+### 5.3 Package Manager
+
+**Goals:**
+- Distribute Jock libraries
+- Dependency management
+- Version resolution
+- Integration with Urbit %yard desks
+
+**Design:**
+```
+jock.toml:
+  [package]
+  name = "my-app"
+  version = "0.1.0"
+  
+  [dependencies]
+  stdlib = "1.0"
+  json = "0.5"
+
+Command:
+  jock build
+  jock install <package>
+  jock publish
+```
+
+---
+
+## Phase 6: Standard Library
+
+### 6.1 Core Modules
+
+**collections:**
+- `List<T>`: standard list operations
+- `Set<T>`: ordered sets
+- `Dict<K, V>`: maps/dictionaries
+- `Vector<T>`: contiguous arrays (Lagoon ndray)
+
+**string:**
+- `Chars` operations: concat, split, trim
+- `String` operations: convert to/from list
+- Unicode support
+- Parsing helpers
+
+**math:**
+- Arithmetic traits implementation
+- Trig functions (via jets)
+- Random number generation (from entropy)
+
+**time:**
+- `Date` operations
+- `Span` (duration) arithmetic
+- Formatting/parsing
+
+**io:**
+- HTTP client/server helpers
+- File system access (via Clay)
+- JSON serialization
+
+**crypto:**
+- Hashing (SHA, Blake)
+- Signing/verification
+- Encryption (AES, ChaCha)
+
+### 6.2 Gall Helpers
+
+**agent-utils:**
+- Standard agent template
+- Card builders
+- Subscription management
+- State persistence patterns
+
+**scry:**
+- Type-safe scry interface
+- Common scry patterns
+- Cache management
+
+---
+
+## Phase 7: Testing & Documentation
+
+### 7.1 Test Framework Expansion
+
+**Unit Testing:**
+```jock
+test "arithmetic" {
+  assert 1 + 1 == 2
+  assert 5 - 3 == 2
+  assert 4 * 3 == 12
+}
+
+test "list operations" {
+  let xs = [1, 2, 3];
+  assert xs.length() == 3
+  assert xs.first() == [~ 1]
+}
+```
+
+**Property Testing:**
+```jock
+property "addition commutative" {
+  forall (a: Atom, b: Atom) {
+    a + b == b + a
+  }
+}
+```
+
+**Integration Testing:**
+- Full NockApp kernel tests
+- Gall agent lifecycle tests
+- Network interaction tests
+
+### 7.2 Documentation
+
+**Required Docs:**
+- Language reference (complete)
+- Standard library API docs
+- NockApp guide
+- Gall agent tutorial
+- Compiler internals (design docs)
+- Nock compilation strategy
+- Migration guide (Hoon → Jock)
+
+**Doc Generation:**
+- Extract from source comments
+- Generate markdown/HTML
+- Host on docs.jock.org
+- Searchable with examples
+
+---
+
+## Implementation Priorities
+
+### P0 (Critical Path - 3 months)
+1. Type system overhaul (structs, traits, unions, generics)
+2. Path syntax completion
+3. NockApp kernel interface
+4. Basic standard library (collections, string, math)
+
+### P1 (Production Ready - 3 months)
+5. Gall agent primitives
+6. Compiler optimization (sKa, basic jet matching)
+7. LSP server (basic features)
+8. Comprehensive test suite
+
+### P2 (Developer Experience - 3 months)
+9. Debugger
+10. Package manager
+11. Full standard library
+12. Complete documentation
+
+### P3 (Nice to Have - 6 months)
+13. Advanced optimizations
+14. Property testing framework
+15. Formal verification tools
+16. Visual debugging tools
+
+---
+
+## Technical Constraints & Design Decisions
+
+### Hard Constraints
+1. **Subject-oriented compilation:** Every operation must work with Nock's subject model
+2. **Binary tree addressing:** All data access via axis notation
+3. **Functional purity:** No mutable state at Nock level
+4. **Homoiconicity:** Code and data unified as nouns
+
+### Design Principles
+1. **Pragmatism over elegance:** Choose solutions that work in production
+2. **Explicit over implicit:** Require type annotations where inference is complex
+3. **Safety with escape hatches:** Type system enforced, but allow `Noun` escape
+4. **Hoon compatibility:** FFI should be seamless and bidirectional
+5. **Performance awareness:** Naive compilation acceptable, but provide optimization path
+
+### Known Trade-offs
+1. **Monomorphization vs. code size:** Accept code duplication for performance
+2. **Explicit typing vs. ergonomics:** Reduce bugs at cost of verbosity
+3. **Nock fidelity vs. abstractions:** Stay close to metal, add sugar carefully
+4. **Innovation vs. stability:** Beta breaking changes acceptable, then stabilize
+
+---
+
+## Success Criteria
+
+### Beta Release (6 months)
+- [ ] Type system complete (structs, traits, unions, generics)
+- [ ] NockApp kernel interface working
+- [ ] Path syntax implemented
+- [ ] Basic standard library
+- [ ] 100+ passing tests
+- [ ] Documentation 80% complete
+
+### 1.0 Release (12 months)
+- [ ] Gall agent support
+- [ ] Compiler optimization (sKa)
+- [ ] LSP server (basic)
+- [ ] Full standard library
+- [ ] 500+ passing tests
+- [ ] Production apps deployed
+
+### 2.0 Release (18 months)
+- [ ] Debugger
+- [ ] Package manager
+- [ ] Advanced optimizations
+- [ ] Property testing
+- [ ] Enterprise adoption
+
+---
+
+## Migration Strategy (Hoon → Jock)
+
+### Automated Translation
+**Feasible:**
+- Basic arithmetic, logic
+- Function definitions
+- Struct/core definitions
+- Simple control flow
+
+**Requires Manual Work:**
+- Irregular Hoon syntax (`?:`, `?@`, etc.)
+- Complex macros (`=<`, `=^`, etc.)
+- Type system edge cases
+- Idiomatic patterns
+
+### Translation Tool
+```bash
+hoon2jock input.hoon > output.jock
+```
+
+**Strategy:**
+1. Parse Hoon AST (using Hoon parser)
+2. Map to Jock AST (semantic translation)
+3. Generate Jock source
+4. Manual review + cleanup
+
+---
+
+## Risk Mitigation
+
+### Technical Risks
+1. **Type system complexity:** Mitigate with staged rollout, extensive testing
+2. **Compiler bugs:** Mitigate with property testing, fuzzing, formal methods
+3. **Performance issues:** Mitigate with benchmarking, profiling, jet matching
+4. **NockApp incompatibility:** Mitigate with integration tests, real-world apps
+
+### Adoption Risks
+1. **Learning curve:** Mitigate with tutorials, examples, migration guide
+2. **Hoon ecosystem lock-in:** Mitigate with excellent FFI, gradual migration
+3. **Tooling gaps:** Mitigate with LSP early, prioritize developer experience
+4. **Documentation debt:** Mitigate with docs-first approach, examples in tests
+
+---
+
+## Appendix A: Nock Compilation Patterns
+
+### Function Calls
+```jock
+func add(a: Atom, b: Atom) -> Atom {
+  a + b
+}
+add(3, 5)
+```
+
+Compiles to:
+```nock
+// Gate construction
+[8 [1 0] [1 [4 4 0 1] 0 1] 0 1]
+// Slam: [[3 5] gate] -> 8
+[9 2 10 [6 7 [0 3] 1 3 5] 0 1]
+```
+
+### Recursion
+```jock
+func factorial(n: Atom) -> Atom {
+  if n == 0 {
+    1
+  } else {
+    n * $(n - 1)
+  }
+}
+```
+
+Compiles to:
+```nock
+// Use $ as recursion point (Nock 9 with axis 2)
+[8 [1 n] 
+  6 [5 [0 2] 1 0]
+    [1 1]
+    [4 4 [0 2] [9 2 10 [6 [4 0 6] 0 2] 0 1]]
+  0 1]
+```
+
+### Loop Constructs
+```jock
+let a = 43;
+let b = 0;
+loop;
+if a == +(b) {
+  b
+} else {
+  b = +(b);
+  recur
+}
+```
+
+Compiles to:
+```nock
+[8 [1 43]
+ 8 [1 0]
+ 8 [1 0]
+ 6 [5 [0 6] [4 0 14]]
+   [0 14]
+   [7 [10 [14 1] 0 1] 9 2 10 [6 1 0] 0 1]
+ 0 1]
+```
+
+---
+
+## Appendix B: Subject Layout Examples
+
+### Simple Function Subject
+```jock
+let x = 5;
+let y = 10;
+func add_xy(z: Atom) -> Atom {
+  x + y + z
+}
+```
+
+Subject structure:
+```
+[battery payload]
+  battery: [[add_xy-formula] context]
+  payload: [z [y [x prior-subject]]]
+
+Axes:
+  +2: battery
+  +3: payload (entire)
+  +6: z
+  +7: [y [x prior-subject]]
+  +14: y
+  +15: [x prior-subject]
+  +30: x
+```
+
+### Class Subject
+```jock
+class Counter(value: Atom) {
+  increment(self) -> Counter {
+    Counter(self.value + 1)
+  }
+  
+  get(self) -> Atom {
+    self.value
+  }
+}
+```
+
+Subject structure:
+```
+[battery sample]
+  battery: [[increment get] ...]
+  sample: value (Atom)
+
+Method resolution:
+  - Walk to find arm by name
+  - Slam with sample
+```
+
+---
+
+## Appendix C: Recommended Reading
+
+### Nock & Urbit Fundamentals
+- [Nock Definition](https://docs.urbit.org/language/nock/reference/definition)
+- [~timluc-miptev: Nock for Everyday Coders](https://blog.timlucmiptev.space/part1.html)
+- [Hoon School](https://docs.urbit.org/courses/hoon-school)
+
+### Type Systems
+- *Types and Programming Languages* (Pierce)
+- *Advanced Topics in Types and Programming Languages* (Pierce)
+- Rust documentation (trait system reference)
+- Swift documentation (protocol-oriented programming)
+
+### Compiler Design
+- *Compilers: Principles, Techniques, and Tools* (Dragon Book)
+- *Engineering a Compiler* (Cooper & Torczon)
+- LLVM documentation (optimization passes)
+
+### Language Design
+- *Structure and Interpretation of Computer Programs* (Abelson & Sussman)
+- *Practical Foundations for Programming Languages* (Harper)
+- *The Implementation of Functional Programming Languages* (Peyton Jones)
+
+---
+
+## Appendix D: Community & Resources
+
+### Communication Channels
+- GitHub Issues: Bug reports, feature requests
+- Urbit Groups: Developer discussions
+- Twitter/X: @JockNockISA
+- Discord: Nockchain community
+
+### Contributing Guidelines
+1. Read PHILOSOPHY.md and ROADMAP.md
+2. Check existing issues/PRs
+3. Small PRs preferred
+4. Tests required for new features
+5. Documentation required for new syntax
+
+### Code Review Standards
+- Compiles without warnings
+- Passes all tests
+- Maintains type safety
+- Follows naming conventions
+- Includes documentation
+- Performance considerations noted
+
+---
+
+## Conclusion
+
+This spec provides a comprehensive roadmap for completing Jock. The type system overhaul is the critical path, followed by NockApp/Gall integration. With focused effort, Jock can become the practical, production-ready language for Nock development within 12-18 months.
+
+The cypherpunk vision: deterministic computation, formally verifiable code, sovereign infrastructure. Jock is a key enabler.
+
+Let's build something that survives contact with reality.
+
+---
+
+**Document Status:** Living specification, last updated 2025-01-22
+**Next Review:** After Beta type system implementation
+**Maintainer:** Senior engineering team, community input welcome

--- a/docs/JOCK_IMPLEMENTATION_ROADMAP.md
+++ b/docs/JOCK_IMPLEMENTATION_ROADMAP.md
@@ -1,0 +1,801 @@
+# Jock Implementation Roadmap: Immediate Next Steps
+## For Claude Code Execution
+
+**Repository:** github.com/zorp-corp/jock-lang (main) / github.com/sigilante/jock-lang (development fork)
+**Current Branch:** Beta development
+**Target:** Production-ready type system + NockApp compatibility
+
+---
+
+## Sprint 1: Type System Foundation (2 weeks)
+
+### Task 1.1: Struct Implementation
+**Location:** `/crates/jockc/hoon/lib/jock.hoon`
+
+**Requirements:**
+- Parse struct definitions with named fields
+- Generate AST nodes for struct types
+- Compile to Nock door structure
+- Support field access via `.` operator
+- Implement structural type checking
+
+**Example Code:**
+```jock
+struct Point {
+  x: Real
+  y: Real
+}
+
+let p = Point(1.0, 2.0);
+let x_val = p.x;
+```
+
+**Nock Compilation Target:**
+```nock
+// Point as door: [battery sample]
+// sample: [x y]
+// battery: [constructor field-accessors ...]
+[8 [1 [x-val y-val]] [1 /* arms */] 0 1]
+```
+
+**Acceptance Criteria:**
+- [ ] Parser recognizes `struct` keyword and field definitions
+- [ ] AST includes struct type information
+- [ ] Compiler generates correct Nock core
+- [ ] Field access compiles to correct axis lookup
+- [ ] Type checker validates field types
+- [ ] Test: Can create struct, access fields, pass around
+
+### Task 1.2: Newtype Wrappers
+**Location:** Same file
+
+**Requirements:**
+- Single-field structs create nominal types
+- Require explicit cast to unwrap
+- Maintain type distinction at compile time
+
+**Example:**
+```jock
+struct UserId(Atom)
+
+let id = UserId(42);
+let raw = id as Atom;  // OK
+let bad: Atom = id;    // Error: type mismatch
+```
+
+**Implementation Notes:**
+- Use same door structure as structs
+- Type checker maintains distinction
+- `as` operator performs structural cast
+
+**Acceptance Criteria:**
+- [ ] Single-field structs parse correctly
+- [ ] Type system treats as distinct type
+- [ ] Cast operator works correctly
+- [ ] Compile-time type errors for mismatches
+
+### Task 1.3: Type Aliases
+**Location:** Same file
+
+**Requirements:**
+- Transparent aliases (no wrapper)
+- Compile-time substitution
+- Support generic aliases
+
+**Example:**
+```jock
+alias Path = List<Chars>
+alias Wire = Path
+
+let p: Path = /foo/bar;
+let w: Wire = p;  // No cast needed
+```
+
+**Implementation:**
+- Resolve aliases during type checking phase
+- Substitute at AST level
+- No runtime distinction
+
+**Acceptance Criteria:**
+- [ ] Parser recognizes `alias` keyword
+- [ ] Type checker substitutes aliases
+- [ ] No cast required for compatible aliases
+- [ ] Generic aliases work correctly
+
+---
+
+## Sprint 2: Traits & Impl (2 weeks)
+
+### Task 2.1: Trait Definition
+**Location:** `/crates/jockc/hoon/lib/jock.hoon`
+
+**Requirements:**
+- Define trait syntax
+- Parse trait definitions
+- Store trait requirements in compilation environment
+- Support `Self` type parameter
+
+**Example:**
+```jock
+trait Arithmetic {
+  add(self, other: Self) -> Self
+  neg(self) -> Self
+}
+```
+
+**Implementation Strategy:**
+- Trait = named collection of method signatures
+- Store in compilation environment as type constraint
+- No code generation at trait definition
+
+**Acceptance Criteria:**
+- [ ] Parser recognizes `trait` keyword
+- [ ] Trait definitions stored in environment
+- [ ] Method signatures validated
+- [ ] `Self` type parameter works
+
+### Task 2.2: Impl Blocks (via Class)
+**Location:** Same file
+
+**Requirements:**
+- Use `class` keyword for subject scope management
+- Compile impl to Nock core with methods in battery
+- Subject-oriented method resolution
+
+**Example:**
+```jock
+class Point(x: Atom, y: Atom) {
+  add(self, other: Point) -> Point {
+    Point(self.x + other.x, self.y + other.y)
+  }
+  
+  neg(self) -> Point {
+    Point(-self.x, -self.y)
+  }
+}
+```
+
+**Nock Compilation:**
+- Battery contains method formulas
+- Sample contains state (x, y)
+- Method call = slot access + slam
+
+**Acceptance Criteria:**
+- [ ] `class` syntax parses with methods
+- [ ] Methods compile to battery arms
+- [ ] `self` parameter works correctly
+- [ ] Method calls resolve via subject walk
+- [ ] Name collision detection works
+
+### Task 2.3: Method Resolution
+**Location:** Compiler type checker
+
+**Algorithm:**
+1. Walk subject tree (depth-first)
+2. Find arm named `method` where declaring type matches target
+3. Emit Nock: `[9 axis-of-arm [0 axis-of-subject]]`
+
+**Edge Cases:**
+- Name collisions: compile error in v1
+- Type mismatches: compile error
+- Missing methods: compile error
+
+**Acceptance Criteria:**
+- [ ] Method resolution algorithm implemented
+- [ ] Correct Nock generated for method calls
+- [ ] Type checking validates method exists
+- [ ] Clear error messages for failures
+
+---
+
+## Sprint 3: Unions & Pattern Matching (2 weeks)
+
+### Task 3.1: Union Definition
+**Location:** Parser + type system
+
+**Requirements:**
+- Head-tagged cells for variants
+- Support multiple fields per variant
+- Type-safe construction
+
+**Example:**
+```jock
+union Result {
+  case ok(value: Atom)
+  case err(code: Atom, msg: Chars)
+}
+
+let success = Result::ok(42);
+let failure = Result::err(404, "Not found");
+```
+
+**Nock Representation:**
+- `ok(42)` → `[%ok 42]`
+- `err(404, "Not found")` → `[%err 404 "Not found"]`
+
+**Acceptance Criteria:**
+- [ ] Union definitions parse
+- [ ] Variant construction works
+- [ ] Head tags generated correctly
+- [ ] Type checker validates usage
+
+### Task 3.2: Pattern Matching
+**Location:** Compiler control flow
+
+**Requirements:**
+- `match` or `switch` keyword
+- Exhaustiveness checking
+- Binding variables from patterns
+
+**Example:**
+```jock
+match result {
+  ok(val) -> val * 2
+  err(code, msg) -> {
+    print("Error " + code + ": " + msg);
+    0
+  }
+}
+```
+
+**Implementation:**
+- Compile to nested Nock 6 (if-then-else)
+- Test head tag with Nock 5 (equality)
+- Extract fields with Nock 0 (slot)
+
+**Acceptance Criteria:**
+- [ ] Pattern matching syntax parses
+- [ ] Exhaustiveness checker works
+- [ ] Variable binding works
+- [ ] Compiles to correct Nock
+- [ ] Type checker validates patterns
+
+---
+
+## Sprint 4: Generics & Monomorphization (2 weeks)
+
+### Task 4.1: Generic Function Syntax
+**Location:** Parser + type system
+
+**Requirements:**
+- Type parameters in angle brackets
+- Type parameter binding at call site
+- Explicit type annotations on parameters
+
+**Example:**
+```jock
+func first<T>(xs: List<T>) -> ?T {
+  match xs {
+    [] -> ~
+    [head, ..tail] -> [~ head]
+  }
+}
+
+let x = first([1, 2, 3]);  // T = Atom inferred
+```
+
+**Acceptance Criteria:**
+- [ ] Generic syntax parses
+- [ ] Type parameters tracked in environment
+- [ ] Call site type inference works
+- [ ] Empty collection annotation required
+
+### Task 4.2: Monomorphization Pass
+**Location:** Compiler backend
+
+**Requirements:**
+- Generate separate Nock for each concrete type
+- Maintain mapping: (function, type args) → compiled Nock
+- No runtime polymorphism
+
+**Implementation Strategy:**
+1. During compilation, track generic function calls
+2. For each unique type instantiation, generate specialized Nock
+3. Replace generic calls with specialized versions
+
+**Acceptance Criteria:**
+- [ ] Monomorphization generates correct Nock
+- [ ] Each type instantiation compiled separately
+- [ ] Performance is good (no overhead)
+- [ ] Test with multiple type instantiations
+
+---
+
+## Sprint 5: NockApp Kernel Interface (1 week)
+
+### Task 5.1: Kernel Type Definitions
+**Location:** `/common/hoon/jib/kernel.jock` (new file)
+
+**Create Standard Types:**
+```jock
+alias Tang = List<Chars>
+alias Term = Chars
+
+struct Goof {
+  mote: Term
+  tang: Tang
+}
+
+alias Wire = Path
+
+struct Input {
+  eny: Uint
+  our: Hex
+  now: Date
+  cause: Noun
+}
+
+struct Ovum {
+  wire: Wire
+  input: Input
+}
+
+struct Crud {
+  goof: Goof
+  input: Input
+}
+```
+
+**Acceptance Criteria:**
+- [ ] Types defined in standard library
+- [ ] Compile correctly to Nock
+- [ ] Compatible with Hoon equivalents
+
+### Task 5.2: Kernel Class Template
+**Location:** `/common/hoon/jib/kernel-template.jock` (new file)
+
+**Create:**
+```jock
+class Kernel<S>(state: S) {
+  load(old: Noun) -> S {
+    // Override in subclass
+    old as! S
+  }
+  
+  wish(expr: Noun) -> Noun {
+    crash("wish not implemented")
+  }
+  
+  peek(path: Path) -> ?(?(Noun)) {
+    // Override in subclass
+    ~
+  }
+  
+  poke(cause: Noun) -> (List<Noun>, S) {
+    // Override in subclass
+    ([], state)
+  }
+}
+```
+
+**Acceptance Criteria:**
+- [ ] Template compiles
+- [ ] Arms at correct axes (+4, +10, +22, +23)
+- [ ] Can be extended by user code
+- [ ] Test with simple kernel
+
+### Task 5.3: Integration Test
+**Location:** `/common/hoon/try/simple-kernel.jock` (new file)
+
+**Write Simple Kernel:**
+```jock
+struct CounterState {
+  count: Atom
+}
+
+class CounterKernel extends Kernel<CounterState> {
+  peek(path: Path) -> ?(?(Noun)) {
+    match path {
+      /count -> [~ ~ state.count]
+      _ -> [~ ~]
+    }
+  }
+  
+  poke(cause: Noun) -> (List<Noun>, CounterState) {
+    match cause {
+      [%increment, n] -> {
+        let new_state = CounterState(state.count + n);
+        ([], new_state)
+      }
+      _ -> ([], state)
+    }
+  }
+}
+```
+
+**Test Via:**
+```bash
+./jockc ./common/hoon/try/simple-kernel --import-dir ./common/hoon/jib
+# Should build and run successfully
+```
+
+**Acceptance Criteria:**
+- [ ] Kernel compiles to valid Nock
+- [ ] Arms at correct axes
+- [ ] Can be invoked via NockApp runtime
+- [ ] State persists across pokes
+
+---
+
+## Sprint 6: Path Syntax & Standard Library (1 week)
+
+### Task 6.1: Path Parser
+**Location:** Parser in `/crates/jockc/hoon/lib/jock.hoon`
+
+**Requirements:**
+- Recognize `/foo/bar/baz` syntax
+- Support interpolation: `/(variable)`
+- Compile to `List<Chars>`
+
+**Example:**
+```jock
+let segment = "users";
+let user_id = "123";
+let path = /(segment)/(user_id)/profile;
+// Compiles to: ["users" "123" "profile"]
+```
+
+**Acceptance Criteria:**
+- [ ] Path syntax parses
+- [ ] Interpolation works
+- [ ] Compiles to correct Nock
+- [ ] Type checking validates interpolated values
+
+### Task 6.2: Basic Standard Library
+**Location:** `/common/hoon/jib/*.jock` (new files)
+
+**Create:**
+- `list.jock`: length, first, last, append, concat, reverse
+- `string.jock`: concat, split, trim, to_chars, from_chars
+- `math.jock`: basic arithmetic, min, max, abs
+- `option.jock`: map, flat_map, unwrap_or, is_some
+
+**Example (`list.jock`):**
+```jock
+func length<T>(xs: List<T>) -> Atom {
+  match xs {
+    [] -> 0
+    [_, ..tail] -> 1 + length(tail)
+  }
+}
+
+func first<T>(xs: List<T>) -> ?T {
+  match xs {
+    [] -> ~
+    [head, ..] -> [~ head]
+  }
+}
+```
+
+**Acceptance Criteria:**
+- [ ] Standard library modules compile
+- [ ] Can be imported in user code
+- [ ] Functions work correctly
+- [ ] Well-documented with examples
+
+---
+
+## Sprint 7: Optimization & Polish (1 week)
+
+### Task 7.1: Basic Subject Knowledge Analysis
+**Location:** Compiler optimizer
+
+**Requirements:**
+- Track known subject structure during compilation
+- Compute axes statically
+- Fold constants where possible
+
+**Example Optimization:**
+```jock
+let x = 5;
+let y = x + 3;
+y * 2
+```
+
+**Before:**
+```nock
+[8 [1 5] 8 [7 [0 2] 4 4 4 0 1] 7 [0 2] 4 4 4 4 0 1] 0 1]
+```
+
+**After:**
+```nock
+[1 16]  // (5 + 3) * 2 = 16
+```
+
+**Acceptance Criteria:**
+- [ ] Constant folding works
+- [ ] Static axis computation works
+- [ ] Benchmark shows improvement
+- [ ] No correctness regressions
+
+### Task 7.2: Error Messages
+**Location:** All compiler phases
+
+**Requirements:**
+- Clear, actionable error messages
+- Show source location
+- Suggest fixes where possible
+
+**Example:**
+```
+Error: Type mismatch at line 10, column 5
+  Expected: Atom
+  Found:    List<Atom>
+
+  let x: Atom = [1, 2, 3];
+                ^^^^^^^^^
+
+Suggestion: Did you mean to use List<Atom> as the type?
+```
+
+**Acceptance Criteria:**
+- [ ] All compiler errors include source location
+- [ ] Type errors show expected vs. actual
+- [ ] Suggestions provided where applicable
+- [ ] Format is consistent across errors
+
+### Task 7.3: Documentation
+**Location:** `/docs/*.md` (new directory)
+
+**Create:**
+- `LANGUAGE_REFERENCE.md`: Complete syntax guide
+- `TYPE_SYSTEM.md`: Types, traits, generics
+- `NOCKAPP_GUIDE.md`: Building kernels
+- `STDLIB_API.md`: Standard library reference
+- `EXAMPLES.md`: Practical examples
+
+**Acceptance Criteria:**
+- [ ] Documentation is comprehensive
+- [ ] Examples compile and run
+- [ ] Clear explanations with rationale
+- [ ] Searchable and well-organized
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+**Location:** `/crates/jockc/hoon/lib/test-jock.hoon`
+
+**Add Tests For:**
+- [ ] Struct creation and field access
+- [ ] Newtype wrapping and unwrapping
+- [ ] Type aliases
+- [ ] Trait definitions
+- [ ] Impl blocks and method calls
+- [ ] Union construction and matching
+- [ ] Generic functions
+- [ ] Path syntax
+- [ ] Standard library functions
+
+### Integration Tests
+**Location:** `/common/hoon/try/*-test.jock`
+
+**Add Tests For:**
+- [ ] Simple NockApp kernel
+- [ ] Stateful kernel with multiple pokes
+- [ ] Kernel with working peek
+- [ ] Complex type composition
+- [ ] Real-world-ish applications
+
+### Performance Benchmarks
+**Location:** `/benchmarks/*.jock`
+
+**Benchmark:**
+- [ ] Fibonacci (recursive)
+- [ ] List operations (map, filter, fold)
+- [ ] Struct field access
+- [ ] Method dispatch overhead
+- [ ] Pattern matching cost
+
+---
+
+## Continuous Integration
+
+### Build Checks
+- [ ] All code compiles without warnings
+- [ ] All tests pass
+- [ ] No regressions in existing functionality
+- [ ] Documentation builds
+
+### Code Quality
+- [ ] Consistent naming conventions
+- [ ] Comments explain non-obvious code
+- [ ] No dead code
+- [ ] Hoon code follows style guide
+
+---
+
+## Definition of Done
+
+### Feature Complete When:
+1. Implementation matches specification
+2. Unit tests pass (100% coverage for new code)
+3. Integration tests pass
+4. Documentation written
+5. Examples work
+6. Code reviewed
+7. Performance acceptable (no worse than 2x naive)
+8. No known bugs
+
+### Beta Release When:
+- [ ] All Sprint 1-6 tasks complete
+- [ ] 100+ tests passing
+- [ ] Documentation 80% complete
+- [ ] At least 3 example applications work
+- [ ] Type system validates all examples
+- [ ] NockApp kernel interface tested
+
+---
+
+## Tools & Environment
+
+### Required Tools
+- Rust toolchain (1.70+)
+- Hoon compiler (from nockchain)
+- NockVM (from nockchain)
+- Git
+- Make
+
+### Build Commands
+```bash
+# Build jockc compiler
+make jockc
+
+# Build jockt test runner
+make jockt
+
+# Run specific test
+./jockt exec <test-number> --import-dir ./common/hoon/jib
+
+# Run all tests
+./jockt test-all --import-dir ./common/hoon/jib
+
+# Run example
+./jockc ./common/hoon/try/<example>.jock --import-dir ./common/hoon/jib
+```
+
+### Development Workflow
+1. Edit Hoon code in `/crates/jockc/hoon/lib/jock.hoon`
+2. Edit Rust wrapper in `/crates/jockc/main.rs` (if needed)
+3. Run `make jockc` to rebuild
+4. Test with `./jockt` or `./jockc`
+5. Commit with clear message
+
+---
+
+## Immediate Next Actions (This Week)
+
+### Priority 1: Get Development Environment Working
+1. Clone repository
+2. Build hoonc from nockchain
+3. Build jockc and jockt
+4. Run existing tests to verify setup
+5. Read through existing Hoon code to understand structure
+
+### Priority 2: Start Struct Implementation
+1. Study existing type system in `/crates/jockc/hoon/lib/jock.hoon`
+2. Add parser support for `struct` keyword
+3. Extend AST to include struct nodes
+4. Implement basic struct compilation (no methods yet)
+5. Write tests for struct creation
+
+### Priority 3: Document Current State
+1. Inventory what's implemented vs. spec
+2. Document known bugs/issues
+3. Create task breakdown for remaining work
+4. Set up project tracking (GitHub issues)
+
+---
+
+## Questions to Answer During Implementation
+
+### Type System
+- [ ] How do we handle recursive types?
+- [ ] What's the scoping rule for type parameters?
+- [ ] How do we handle trait coherence?
+- [ ] What's the story for type inference limits?
+
+### Compilation
+- [ ] What's the exact Nock pattern for method dispatch?
+- [ ] How do we ensure jet matching works?
+- [ ] What's the memory layout for complex nested types?
+- [ ] How do we handle stack overflow in recursion?
+
+### Interop
+- [ ] How do we call Jock from Hoon?
+- [ ] How do we handle Hoon irregular syntax in FFI?
+- [ ] What's the ABI for Jock/Hoon function boundaries?
+- [ ] How do we share types between Jock and Hoon?
+
+---
+
+## Success Metrics
+
+### Week 1-2 (Sprint 1)
+- Structs parse and compile
+- Can create struct, access fields
+- Type checker validates struct usage
+- 10+ tests passing
+
+### Week 3-4 (Sprint 2)
+- Traits defined and stored
+- Impl blocks compile to cores
+- Method calls work
+- 25+ tests passing
+
+### Week 5-6 (Sprint 3)
+- Unions work with pattern matching
+- Exhaustiveness checking
+- Can build simple Result/Option types
+- 40+ tests passing
+
+### Week 7-8 (Sprint 4)
+- Generics compile with monomorphization
+- Type inference works
+- Standard generic functions (first, map, etc.)
+- 60+ tests passing
+
+### Week 9 (Sprint 5)
+- NockApp kernel template works
+- Simple counter kernel compiles and runs
+- Arms at correct axes
+- 70+ tests passing
+
+### Week 10 (Sprint 6)
+- Path syntax works
+- Basic standard library available
+- Can build small applications
+- 85+ tests passing
+
+### Week 11 (Sprint 7)
+- Optimizations showing improvement
+- Error messages are clear
+- Documentation complete
+- 100+ tests passing
+
+---
+
+## Communication Plan
+
+### Daily Standup (Async)
+- What did I complete yesterday?
+- What am I working on today?
+- Any blockers?
+
+### Weekly Review
+- Progress against sprint goals
+- Demos of working features
+- Adjust priorities if needed
+
+### Monthly Retrospective
+- What went well?
+- What could improve?
+- Update roadmap based on learning
+
+---
+
+## Getting Help
+
+### When Stuck
+1. Read existing code for patterns
+2. Consult Nock documentation
+3. Check Hoon implementation
+4. Ask in Urbit developer groups
+5. Create GitHub issue with minimal reproduction
+
+### Resources
+- Jock docs: https://docs.jock.org
+- Nock spec: https://docs.urbit.org/language/nock
+- Hoon docs: https://docs.urbit.org/language/hoon
+- NockApp: https://github.com/zorp-corp/nockchain
+
+---
+
+This roadmap is aggressive but achievable with focused effort. Each sprint builds on the previous, with clear acceptance criteria and tests. The result will be a production-ready type system and NockApp compatibility, enabling real applications in Jock.
+
+Let's make Nock programming accessible without compromising on rigor or performance. The future is deterministic computation, and Jock is the practical path to get there.
+
+**Status:** Ready for implementation
+**Last Updated:** 2025-01-22
+**Owner:** Claude Code + Senior Engineering Team

--- a/docs/JOCK_NOCK_QUICK_REFERENCE.md
+++ b/docs/JOCK_NOCK_QUICK_REFERENCE.md
@@ -1,0 +1,635 @@
+# Jock-to-Nock Compilation Quick Reference
+## Patterns, Idioms, and Translation Strategies
+
+---
+
+## Fundamental Nock Opcodes
+
+| Op | Name | Form | Meaning |
+|----|------|------|---------|
+| 0  | Slot | `[0 b]` | Tree address `b` of subject |
+| 1  | Constant | `[1 b]` | Literal value `b` |
+| 2  | Eval | `[2 b c]` | `*[*[a b] *[a c]]` |
+| 3  | Cell? | `[3 b]` | 0 if `*[a b]` is cell, else 1 |
+| 4  | Increment | `[4 b]` | `+(*[a b])` |
+| 5  | Equal | `[5 b c]` | 0 if `*[a b]` = `*[a c]`, else 1 |
+| 6  | If | `[6 b c d]` | `*[a c]` if `*[a b]` is 0, else `*[a d]` |
+| 7  | Compose | `[7 b c]` | `*[*[a b] c]` |
+| 8  | Push | `[8 b c]` | `*[[*[a b] a] c]` |
+| 9  | Call | `[9 b c]` | `*[*[a c] [2 [0 1] [0 b]]]` |
+| 10 | Edit | `[10 [b c] d]` | Replace axis `b` with `*[a c]` in `*[a d]` |
+| 11 | Hint | `[11 b c]` | Jet hint, compute `*[a c]` |
+| 12 | Scry | `[12 b c]` | Mock/scry (not used in JockApps) |
+
+---
+
+## Subject Structure & Axes
+
+```
+Tree:     [a b]
+Subject:  [battery payload]
+
+Axes:
+  1 = entire subject
+  2 = head (battery)
+  3 = tail (payload)
+  
+  4 = head of head
+  5 = tail of head
+  6 = head of tail
+  7 = tail of tail
+  
+  2^n     = nth left (head)
+  2^n + 1 = nth right (tail)
+```
+
+**Computing Axes:**
+- Left: `2 * axis`
+- Right: `2 * axis + 1`
+- Parent: `axis / 2` (integer division)
+
+**Example Subject:**
+```
+[battery [arg1 [arg2 [arg3 prior-subject]]]]
+
++1: entire subject
++2: battery
++3: payload = [arg1 [arg2 [arg3 prior-subject]]]
++6: arg1
++7: [arg2 [arg3 prior-subject]]
++14: arg2
++15: [arg3 prior-subject]]
++30: arg3
++31: prior-subject
+```
+
+---
+
+## Variable Binding (Nock 8)
+
+### Simple Let
+```jock
+let x = 42;
+x
+```
+
+Compiles to:
+```nock
+[8 [1 42] [0 2] 0 1]
+// [8 b c] = *[[*[a b] a] c]
+// b = [1 42] = constant 42
+// c = [0 2] = slot 2 (head of extended subject)
+// Subject becomes: [42 original-subject]
+// +2 = x, +3 = original
+```
+
+### Multiple Let Bindings
+```jock
+let x = 5;
+let y = 10;
+x + y
+```
+
+Compiles to:
+```nock
+[8 [1 5]
+  [8 [1 10]
+    [4 4 [0 4] [0 2]]  // add(+4, +2) = add(x, y)
+  0 1]
+0 1]
+// Subject: [10 [5 original]]
+// +2 = y, +4 = x
+```
+
+---
+
+## Function Definitions (Gates)
+
+### Basic Function
+```jock
+func add(x: Atom, y: Atom) -> Atom {
+  x + y
+}
+```
+
+Compiles to gate (door with one arm):
+```nock
+[8 
+  [1 0]              // Default sample [0 0]
+  [1 
+    [6               // Battery: [add-formula context]
+      [5 [0 30] 0 31]     // if sample == [0 0] crash
+      [0 0]               // then crash
+      [4 4 [0 6] [0 7]]   // else add(+6, +7) = add(x, y)
+    ]
+    0
+  ]
+  0 1
+]
+
+// Gate structure: [battery sample]
+// +2 = battery
+// +3 = sample = [x y]
+// +6 = x
+// +7 = y
+```
+
+### Function Call (Slam)
+```jock
+add(3, 5)
+```
+
+Compiles to:
+```nock
+[9 2                    // Call arm at axis +2 (first arm)
+  [0 1]                 // of subject (the gate)
+  [7 [0 3] [1 3 5]]     // with sample replaced by [3 5]
+]
+
+// Full expansion:
+[9 2 
+  10 [6 [1 3 5] 0 1]    // Edit axis +6 (sample) to [3 5]
+  0 1                    // In subject (the gate)
+]
+```
+
+---
+
+## Recursion ($ buc)
+
+### Recursive Function
+```jock
+func factorial(n: Atom) -> Atom {
+  if n == 0 {
+    1
+  } else {
+    n * $(n - 1)
+  }
+}
+```
+
+Compiles to:
+```nock
+[8 [1 0]                 // Default sample
+  [1 
+    [6                   // if-then-else
+      [5 [0 6] [1 0]]    // n == 0
+      [1 1]              // then 1
+      [4 4               // else n *
+        [0 6]            // n
+        [9 2             // recurse: call self
+          10 [6          // with sample replaced
+            [4 0 6]      // n - 1
+            0 1
+          ]
+          0 1
+        ]
+      ]
+    ]
+    0
+  ]
+  0 1
+]
+
+// $ = "call myself at axis +2"
+// Replace sample with new args
+// Subject unchanged (gate structure maintained)
+```
+
+---
+
+## Control Flow
+
+### If-Then-Else
+```jock
+if condition {
+  then_branch
+} else {
+  else_branch
+}
+```
+
+Compiles to:
+```nock
+[6 
+  [/* condition */]     // Test
+  [/* then_branch */]   // True path
+  [/* else_branch */]   // False path
+]
+```
+
+### Loop
+```jock
+let i = 0;
+loop;
+if i == 10 {
+  i
+} else {
+  i = i + 1;
+  recur
+}
+```
+
+Compiles to:
+```nock
+[8 [1 0]                // i = 0
+  [8 [1 0]              // Loop marker (trap)
+    [6                  // if-then-else
+      [5 [0 6] [1 10]]  // i == 10
+      [0 6]             // then i
+      [7                // else
+        [10 [6 [4 0 6] 0 1] 0 1]  // i = i + 1
+        [9 2 0 1]       // recur (call trap at +2)
+      ]
+    ]
+    0 1
+  ]
+  0 1
+]
+```
+
+---
+
+## Data Structures
+
+### Lists
+```jock
+[1, 2, 3]
+```
+
+Compiles to right-nested cells with `~` (null) terminator:
+```nock
+[1 [2 [3 0]]]  // [1 [2 [3 ~]]]
+// 0 represents ~ (null)
+```
+
+### List Operations
+```jock
+// Length
+func length<T>(xs: List<T>) -> Atom {
+  match xs {
+    [] -> 0
+    [_, ..tail] -> 1 + length(tail)
+  }
+}
+```
+
+Compiles to:
+```nock
+[8 [1 0]              // Default sample
+  [1
+    [6                // Pattern match = if-cell
+      [3 [0 6]]       // is cell?
+      [1 0]           // empty -> 0
+      [4              // else 1 +
+        [9 2          // recurse
+          10 [6 [0 7] 0 1]  // with tail
+          0 1
+        ]
+      ]
+    ]
+    0
+  ]
+  0 1
+]
+```
+
+### Tuples/Cells
+```jock
+(1, 2, 3)
+```
+
+Compiles to left-nested cells:
+```nock
+[[1 2] 3]  // or [1 [2 3]], depends on association
+```
+
+### Structs
+```jock
+struct Point { x: Atom, y: Atom }
+Point(3, 5)
+```
+
+Compiles to door instance:
+```nock
+[battery [3 5]]
+// battery = [constructor field-getters ...]
+// sample = [x y] = [3 5]
+```
+
+---
+
+## Type System Compilation
+
+### Newtype Wrapper
+```jock
+struct UserId(Atom)
+let id = UserId(42);
+```
+
+Compiles to:
+```nock
+// Same as: [constructor-battery 42]
+// Type distinction maintained at compile-time only
+// Runtime: just the value in a door
+```
+
+### Trait Implementation
+```jock
+trait Show {
+  show(self) -> Chars
+}
+
+impl Show for Point {
+  show(self) -> Chars {
+    "(" + self.x + ", " + self.y + ")"
+  }
+}
+```
+
+Compiles to:
+```nock
+// Add show arm to Point battery
+// Subject structure:
+[battery sample]
+  battery = [[show-formula] [other-methods]]
+  sample = [x y]
+
+// Method call: p.show()
+[9 axis-of-show        // Call show arm
+  [0 axis-of-p]        // On p instance
+]
+```
+
+---
+
+## Pattern Matching (Unions)
+
+### Union Definition
+```jock
+union Option<T> {
+  case none
+  case some(value: T)
+}
+```
+
+Compiles to tagged cells:
+```nock
+// none: [%none ~] = [0x656e6f6e 0]
+// some(x): [%some x] = [0x656d6f73 x]
+```
+
+### Pattern Match
+```jock
+match opt {
+  none -> 0
+  some(x) -> x
+}
+```
+
+Compiles to:
+```nock
+[6                      // if-then-else
+  [5                    // equality test
+    [0 12]              // head of opt (tag)
+    [1 %none]           // %none tag
+  ]
+  [1 0]                 // then 0
+  [0 13]                // else tail of opt (value)
+]
+```
+
+---
+
+## Standard Library Patterns
+
+### Option Chaining
+```jock
+e?.field
+```
+
+Compiles to:
+```nock
+[6                      // if-then-else
+  [3 [0 /* e-axis */]]  // is e a cell? (not ~)
+  [0 /* field-axis */]  // then access field
+  [1 ~]                 // else ~
+]
+```
+
+### Default Value
+```jock
+e ?? default
+```
+
+Compiles to:
+```nock
+[6                      // if-then-else
+  [3 [0 /* e-axis */]]  // is e a cell?
+  [0 /* e-axis */]      // then e
+  [0 /* default-axis */] // else default
+]
+```
+
+---
+
+## Optimization Patterns
+
+### Constant Folding
+```jock
+5 + 3
+```
+
+**Naive:**
+```nock
+[4 4 4 4 4 [1 5] [1 3]]  // Multiple increments
+```
+
+**Optimized:**
+```nock
+[1 8]  // Compile-time evaluation
+```
+
+### Subject Knowledge Analysis (sKa)
+Track known subject structure to compute axes statically:
+
+```jock
+let x = 42;
+let y = x;
+y
+```
+
+**Naive:**
+```nock
+[8 [1 42]
+  [8 [0 2]  // y = x (dynamic lookup)
+    [0 2]   // return y
+  0 1]
+0 1]
+```
+
+**Optimized (with sKa):**
+```nock
+[1 42]  // Fold to constant, eliminate bindings
+```
+
+### Jet Hints (Nock 11)
+```jock
+x + y  // Should use addition jet
+```
+
+Compiles to:
+```nock
+[11                     // Hint
+  [1 %add]              // Jet hint: use add jet
+  [4 4 [0 6] [0 7]]     // Fallback: increment-based add
+]
+```
+
+---
+
+## NockApp Kernel Patterns
+
+### Kernel Structure
+```jock
+class Kernel(state: State) {
+  load(old: Noun) -> State { /* ... */ }   // +4
+  wish(expr: Noun) -> Noun { /* ... */ }   // +10
+  peek(path: Path) -> ?(?(Noun)) { /* ... */ }  // +22
+  poke(cause: Noun) -> (List<Effect>, State) { /* ... */ }  // +23
+}
+```
+
+Compiles to door with arms at specific axes:
+```nock
+[battery sample]
+  battery:
+    +2: all arms nested
+    +4: load
+    +10: wish
+    +22: peek
+    +23: poke
+  sample: state
+```
+
+### Peek Implementation
+```jock
+peek(path: Path) -> ?(?(Noun)) {
+  match path {
+    /version -> [~ ~ version]
+    /count -> [~ ~ state.count]
+    _ -> [~ ~]  // not found
+  }
+}
+```
+
+Returns:
+- `~` = block (not ready)
+- `[~ ~]` = permanently not available
+- `[~ ~ value]` = success
+
+---
+
+## Common Pitfalls & Solutions
+
+### Pitfall: Incorrect Axis Calculation
+**Problem:** Off-by-one in axis arithmetic
+**Solution:** Draw subject tree, compute manually, verify
+
+### Pitfall: Subject Loss After Push
+**Problem:** After Nock 8, original subject at +3, not +1
+**Solution:** Track subject changes carefully
+
+### Pitfall: Recursion Without Sample Update
+**Problem:** Infinite loop, same args passed
+**Solution:** Use Nock 10 to replace sample before Nock 9
+
+### Pitfall: Missing Crash on Invalid Input
+**Problem:** Function continues with bad data
+**Solution:** Add `[6 [5 sample default] [0 0] formula]` pattern
+
+### Pitfall: Name Shadowing Confusion
+**Problem:** Variable name reused, wrong axis accessed
+**Solution:** Use unique names or track scopes explicitly
+
+---
+
+## Debugging Strategies
+
+### 1. Inspect Compiled Nock
+Print intermediate Nock before optimization:
+```bash
+./jockc --debug file.jock
+```
+
+### 2. Trace Execution
+Use NockVM trace mode:
+```bash
+NOCK_TRACE=1 ./jockc file.jock
+```
+
+### 3. Verify Subject Structure
+Add debug print statements that output subject:
+```jock
+print(this);  // Print entire subject
+```
+
+### 4. Test Small Pieces
+Compile and test functions in isolation:
+```jock
+// test-function.jock
+func add(x: Atom, y: Atom) -> Atom {
+  x + y
+}
+add(3, 5)
+```
+
+### 5. Compare with Hoon
+Compile equivalent Hoon, compare Nock:
+```hoon
+|=  [x=@ y=@]
+(add x y)
+```
+
+---
+
+## Reference Resources
+
+### Nock Specification
+- Official: https://docs.urbit.org/language/nock/reference/definition
+- Tutorial: https://blog.timlucmiptev.space/part1.html
+
+### Hoon Reference
+- Docs: https://docs.urbit.org/language/hoon
+- Guide: https://docs.urbit.org/courses/hoon-school
+
+### Jock Specifics
+- Docs: https://docs.jock.org
+- Repo: https://github.com/zorp-corp/jock-lang
+- Beta spec: See uploaded jock-beta.md
+
+### Tools
+- NockVM: https://github.com/zorp-corp/nockchain
+- jockc: Jock compiler (build from repo)
+- jockt: Test framework (build from repo)
+
+---
+
+## Quick Tips
+
+1. **Always draw the subject tree** before computing axes
+2. **Use Nock 8 sparingly** - each push adds complexity
+3. **Fold constants aggressively** - don't emit `[1 x]` then `[4 [0 2]]`
+4. **Match Hoon patterns** for jet compatibility
+5. **Test edge cases**: 0, ~, single-element lists
+6. **Read compiled Nock** - it teaches correct patterns
+7. **Start simple** - get basic case working, then optimize
+8. **Use type checker** - catch errors at compile time
+9. **Profile before optimizing** - measure, don't guess
+10. **When stuck, consult Hoon** - it's the reference implementation
+
+---
+
+**This is a living document. Update as patterns emerge.**
+
+Last updated: 2025-01-22

--- a/docs/JOCK_STATE_ASSESSMENT.md
+++ b/docs/JOCK_STATE_ASSESSMENT.md
@@ -1,0 +1,264 @@
+# Jock Language State Assessment
+
+**Date:** 2026-01-22
+**Branch Reviewed:** `sigilante/freshwater-ray-finned-fish`
+**Status:** Alpha (Developer Preview → 0.1.0-alpha)
+
+---
+
+## Executive Summary
+
+Jock is a **functional alpha-stage language** targeting the Nock instruction set architecture. It has a working compiler pipeline, a test framework, and basic language features. The codebase is well-organized with clear documentation outlining an ambitious roadmap toward production readiness.
+
+**Current Capability:** Can compile and run basic programs with functions, classes, control flow, lists, and Hoon FFI.
+
+**Gap to Production:** Missing robust type system (traits, generics, unions), NockApp kernel interface, Gall agent support, optimization passes, and developer tooling.
+
+---
+
+## 1. What Works (Implemented)
+
+### Core Compiler Pipeline
+- **Tokenizer:** Text → tokens (complete)
+- **Parser (jeam):** Tokens → AST (complete)
+- **Type Inference (jype):** Basic type tracking (partial)
+- **Code Generation (mint):** AST → Nock (complete for basic features)
+
+### Language Features
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Variables (`let`) | Working | `let x = 42;` |
+| Functions (`func`) | Working | `func add(a:@ b:@) -> @ { a + b }` |
+| Classes | Working | `class Point(x:@ y:@) { ... }` |
+| Lambdas | Working | Inline anonymous functions |
+| Control Flow | Working | `if/else`, `if/else if/else` |
+| Recursion | Working | `$` for self-reference |
+| Loops | Working | `loop/recur` pattern |
+| Pattern Matching | Partial | `match` with type/case matching |
+| Lists | Working | `[1 2 3]`, basic operations |
+| Sets | Working | Via Hoon FFI |
+| Arithmetic | Working | `+`, `-`, `*`, `/`, `%`, `**` |
+| Comparison | Working | `==`, `!=`, `<`, `>`, `<=`, `>=` |
+| Logical Operators | Working | `&&`, `||`, `!` |
+| Hoon FFI | Working | `hoon.add`, `hoon.mul`, etc. |
+| Comments | Working | `//` line, `/* */` block |
+| Print | Partial | Works for literals, variables incomplete |
+
+### Infrastructure
+- **`jockc`:** Compiler CLI (180 lines Rust + Hoon wrappers)
+- **`jockt`:** Test framework CLI (181 lines Rust + test definitions)
+- **45+ test files:** Covering core language features
+- **Build system:** Makefile with `build`, `test`, `exec` targets
+- **Documentation:** README, PHILOSOPHY, ROADMAP, detailed specs in `/docs`
+
+### Example Programs
+The `/common/hoon/try/` directory contains working examples:
+- `hello-world.jock` - Basic output
+- `fib.jock` - Recursive Fibonacci
+- `calculator.jock` - Arithmetic expressions
+- `point.jock` - Class with methods
+
+---
+
+## 2. What's Missing or Broken
+
+### Type System (Critical Path)
+| Feature | Status | Priority |
+|---------|--------|----------|
+| Structs (named fields) | Not implemented | P0 |
+| Newtypes (`struct UserId(Atom)`) | Not implemented | P0 |
+| Type aliases (`alias`) | Not implemented | P1 |
+| Traits | Not implemented | P0 |
+| Impl blocks | Not implemented | P0 |
+| Unions (sum types) | Not implemented | P0 |
+| Generics | Not implemented | P0 |
+| Exhaustive pattern matching | Not implemented | P1 |
+| Option type (`?T`) | Not native | P1 |
+| Option chaining (`?.`, `??`, `!`) | Not implemented | P1 |
+| Cast operators (`as`, `as?`, `as!`) | Not implemented | P1 |
+
+### NockApp/Gall Integration
+| Feature | Status | Priority |
+|---------|--------|----------|
+| Kernel interface (`+load`, `+peek`, `+poke`) | Not implemented | P0 |
+| Path syntax (`/foo/bar`) | Not implemented | P0 |
+| Wire type | Not implemented | P1 |
+| Gall agent primitives | Not implemented | P1 |
+| Effect/Card system | Not implemented | P1 |
+
+### Standard Library
+| Module | Status | Priority |
+|--------|--------|----------|
+| List operations (native) | Via FFI only | P1 |
+| String operations (native) | Via FFI only | P1 |
+| Math functions | Via FFI only | P2 |
+| Option/Result utilities | Not implemented | P1 |
+| Collection types (Dict, Vector) | Not implemented | P2 |
+
+### Compiler Quality
+| Feature | Status | Priority |
+|---------|--------|----------|
+| Subject Knowledge Analysis (sKa) | Not implemented | P1 |
+| Constant folding | Not implemented | P1 |
+| Jet matching/hints | Not implemented | P2 |
+| Clear error messages | Partial | P1 |
+| Source location tracking | Partial | P1 |
+
+### Tooling
+| Tool | Status | Priority |
+|------|--------|----------|
+| LSP server | Not implemented | P2 |
+| Debugger | Not implemented | P2 |
+| Package manager | Not implemented | P3 |
+| REPL | Proof-of-concept only (jojo) | P2 |
+
+---
+
+## 3. Code Architecture
+
+### Repository Structure
+```
+jock-lang/
+├── crates/
+│   ├── jockc/           # Compiler binary
+│   │   ├── main.rs      # CLI driver (180 lines)
+│   │   └── hoon/        # Hoon compiler code
+│   └── jockt/           # Test framework binary
+│       ├── main.rs      # CLI driver (181 lines)
+│       └── hoon/        # Test framework code
+├── common/
+│   └── hoon/
+│       ├── lib/
+│       │   ├── jock.hoon   # MAIN COMPILER (2,913 lines)
+│       │   └── hoon.hoon   # Hoon FFI bindings
+│       ├── try/            # Example programs
+│       └── jib/            # Import directory
+├── docs/                   # Specifications
+└── assets/                 # Compiled JAM files
+```
+
+### Compiler Core (`jock.hoon`)
+The main compiler is a single 2,913-line Hoon file implementing:
+- **Tokenizer:** Character-level lexing
+- **Parser:** Recursive descent → AST
+- **Type checker:** Basic inference
+- **Code generator:** AST → Nock formulas
+- **FFI bridge:** Hoon builtin integration
+
+### Test Framework (`jockt`)
+- 45+ test files covering language features
+- `sequent.hoon` (1,918 lines) - Logic-based testing library
+- `test-jock.hoon` (443 lines) - Test definitions
+
+---
+
+## 4. Technical Assessment
+
+### Strengths
+1. **Clean design:** Clear separation between tokenizer, parser, type checker, and code generator
+2. **Hoon integration:** Good FFI allows leveraging existing Hoon standard library
+3. **Test coverage:** Comprehensive tests for implemented features
+4. **Documentation:** Detailed specs provide clear direction
+5. **Philosophy:** "Legibility above all" leads to readable code
+6. **Build system:** Works, easy to use
+
+### Weaknesses
+1. **Single-file compiler:** 2,913 lines in one file is hard to maintain
+2. **Ad hoc type system:** No formal foundation, will be hard to extend
+3. **No source maps:** Error messages lack precise locations
+4. **Naive compilation:** No optimizations, verbose Nock output
+5. **FFI dependency:** Many features require Hoon FFI rather than native implementations
+
+### Technical Debt
+1. Library map uses `term` keys (should be `path` for versioning)
+2. Variable printing incomplete (PR #53 in progress)
+3. String operations require FFI (PR #59 in progress)
+4. No caching of noun builds (expensive rebuilds)
+5. Left-to-right associativity not yet implemented
+
+---
+
+## 5. Roadmap Assessment
+
+The `/docs/JOCK_IMPLEMENTATION_ROADMAP.md` defines 7 sprints:
+
+| Sprint | Focus | Realistic? |
+|--------|-------|------------|
+| 1 | Structs, newtypes, aliases | Yes |
+| 2 | Traits, impl blocks | Challenging |
+| 3 | Unions, pattern matching | Yes |
+| 4 | Generics, monomorphization | Challenging |
+| 5 | NockApp kernel interface | Yes |
+| 6 | Path syntax, stdlib | Yes |
+| 7 | Optimization, polish | Ongoing |
+
+**Critical Path:** Type system overhaul (Sprints 1-4) is the gating factor for all else.
+
+**Risk Assessment:**
+- Type system complexity may require iteration
+- Compiler architecture may need refactoring to support advanced features
+- Jet matching requires deep Nock/Hoon knowledge
+
+---
+
+## 6. Recommendations
+
+### Immediate Priorities
+1. **Refactor compiler into modules** - Split `jock.hoon` into separate files for tokenizer, parser, type checker, code generator
+2. **Implement structs** - Foundation for all other type features
+3. **Add source location tracking** - Critical for debugging
+4. **Implement path syntax** - Required for NockApp integration
+
+### Medium-term
+1. **Build trait system incrementally** - Start with simple traits, add complexity gradually
+2. **Create standard library in Jock** - Reduce FFI dependency
+3. **Add constant folding** - Low-hanging optimization fruit
+4. **Improve error messages** - Developer experience critical for adoption
+
+### Long-term
+1. **LSP server** - Essential for IDE support
+2. **Package manager** - Required for ecosystem growth
+3. **Formal type system spec** - Prevent ad hoc decisions
+
+---
+
+## 7. Comparison: Spec vs. Reality
+
+| Spec Feature | Implemented? | Gap |
+|--------------|--------------|-----|
+| Basic types (atoms, cells, lists) | Yes | - |
+| Functions with explicit types | Yes | - |
+| Classes with methods | Yes | - |
+| Control flow | Yes | - |
+| Recursion | Yes | - |
+| Structs with named fields | No | Major |
+| Traits and impls | No | Major |
+| Unions (sum types) | No | Major |
+| Generics | No | Major |
+| NockApp kernel | No | Major |
+| Path syntax | No | Major |
+| Option type native | No | Moderate |
+| Compiler optimizations | No | Moderate |
+| LSP/tooling | No | Expected |
+
+---
+
+## 8. Conclusion
+
+Jock is a **promising alpha-stage language** with a working compiler, good test coverage, and clear vision. The gap between current state and production readiness is significant but well-documented.
+
+**What's Needed:**
+1. Type system overhaul (3-6 months of focused work)
+2. NockApp integration (1-2 months)
+3. Standard library expansion (ongoing)
+4. Developer tooling (3-6 months)
+
+**Realistic Timeline to Beta:** 6-9 months with dedicated effort
+**Realistic Timeline to 1.0:** 12-18 months
+
+The foundation is solid. The specifications are thorough. Success depends on sustained execution of the roadmap, particularly the type system work which gates everything else.
+
+---
+
+**Assessment Author:** Claude (automated analysis)
+**Review Status:** Initial assessment, pending team review


### PR DESCRIPTION
This adds support for several new types and type system components. It breaks compatibility with Jock Alpha from June 2025.

Posting a note here about where I was headed with the beta branch.  The state is that I had just implemented the parser for native `Path` syntax (which NockApp needs) and I was working on `alias` next so we can use aliases for `Wire`.

The fundamental problem with the Jock alpha release was that the type system was ad hoc.  That was fine for the time being, but obviously needed to be corrected.  This showed up in two places:

1. Syntax support (handling `Set` and `List`)
2. `class` state and method definition

I opted to back out to a Rust-style `impl` operator.  I had originally intended to remove the `class` keyword and do something like this.  (I am eliding `compose` for a reason I'll explain later, and I'm sloppy with `;` for the same reason.  Doesn't matter for the exposition.)

```
struct Path(List<Chars>);  // corresponds to door sample
impl Path {
    head(self) -> ?Chars {
      // first segment
    }
    tail(self) -> Path {
      // rest of path
    }
    parent(self) -> Path {
      // all but last
    }
    leaf(self) -> ?Chars {
      // last segment
    }
};
```

I've recently decided that this introduces subject scope issues and it's better to retain `class` and explicitly corral the implementation, something like this.

```
class Path(List<Chars>) {
    head(self) -> ?Chars {
      // first segment
    }
    tail(self) -> Path {
      // rest of path
    }
    parent(self) -> Path {
      // all but last
    }
    leaf(self) -> ?Chars {
      // last segment
    }
    concat impl List {
      ...
    }
};
```

(You do want `struct` or `type` still for product types.)

Anyway, here's a summary of where I was going in this branch, modulo the `class` caveat above:

### Struct

(Note:  see `class` discussion above.)

```swift
struct Point(x: @ y: @);
```

Single-element `struct`s:

```
alias Path List<Chars>; // transparent
struct UserId(Atom); // nominal wrapper

// Alias: no cast needed (see next section)
let p: Path = /foo/bar;
let q: List<Chars> = p; // OK

// Newtype: cast to unwrap
let id = UserId(42);
let raw = id as Atom; // OK, same shape
let bad: Atom = id; // Error: type mismatch
```

###  Aliases

```swift
alias Path List<Chars> // transparent alias
struct UserId(Atom) // opaque single-field wrapper
struct Point(x: Atom y: Atom) // named fields
```

These need to be resolved at compile time because they have to be set within the current subject scope, i.e. not completely lazily.

Example:

```swift
alias Path = List<Chars>;
let p = /foo/bar/(segment)/baz;
let q = /;
let r = /users/(user-id as Chars)/profile;
(p q r)
```

### Traits

```swift
trait Arithmetic {
    add(self other:Self) -> Self
    neg(self) -> Self
}
```

- `Self` is only type parameter (could be `This` or `this`; we have the latter in some form already but it's a little different still)
- No associated types
- No multi-param traits

I played a lot with terminology here.  Also considered `#1` and `#`, `##` as options.

#### Trait Loss on Cast

```swift
impl Arithmetic for Vec2 { ... };

let v = Vec2(1 2);
v.add(Vec2(3 4))  // OK

let p:Point = v as Point;
p.add(Point(3 4))  // Error: no impl for Point
```

Cast changes type label. Impl lookup uses new type. Traits don't follow the data.

### Union

```swift
union Result {
    case ok(value:Atom)
    case err(code:Atom msg:Chars)
}
```

Head-tagged cells: `[%ok value]`, `[%err code msg]`

No generics on unions for v1.

Pattern matching via `switch` or `match` later, following `?+` pattern.

### Higher-Order Functions

```swift
func map<T U>(f: T -> U  xs: List<T>) -> List<U> {
    ...
}
```

- Explicit parameter types required
- Explicit return type required
- Type parameters: single uppercase letters
- Forward inference in body
- Monomorphized at call site

This feels more like a protocol/trait definition still and I want to play with alternatives.  See Generics below.

### Lambda

```swift
lambda (x: @ y: @) -> @ { x + y }
```

Explicit types required on parameters and return.

### Object

```swift
object {
    func helper(n: @) -> @ { ... }
    constant = 42
}
```

Sample-less core, no `$` arm. Arms accessible by name within scope.

### Generics

```swift
func first<T>(xs: List<T>) -> ?T { ... }

let x = first([1 2 3])  // T = Atom, inferred from argument
let y = first([] as List<Atom>)  // T = Atom, explicit
```

- Type parameters bound at call site from argument types
- Empty collections require annotation
- All generics monomorphized (no runtime polymorphism)

### Option Chaining

```
e : T      e.f : U       →   e.f : U
e : ?T     e?.f : U      →   e?.f : ?U
e : ?T     e?.f : ?U     →   e?.f : ??U
e : ?T     d : T         →   e ?? d : T
e : ?T                   →   e! : T  (crash if none)
```

No flattening. `??T` is valid and meaningful.

I actually really like this syntax for handling `+unit`s.  We can even use it for empty tuples.

### Casting

| Syntax | Compile-time     | Runtime    | Use                           |
| ------ | ---------------- | ---------- | ----------------------------- |
| `as`   | structural check | no         | same-shape nominal conversion |
| `as?`  | target known     | mold check | returns `?T`, safe narrowing  |
| `as!`  | target known     | mold check | returns `T`, crash on fail    |

Structural cast ignores field names:

```swift
struct Point(x:Real y:Real)
struct Coord(lat:Real lon:Real)

let c = Coord(1 2);
let p: Point = c as Point;
```

---

### Subject-Oriented Method Resolution

The subject is a typed binary tree. As code composes:

```swift
compose
  with this; struct Point(x: @ y: @);
```

Subject type grows:
```swift
[[Arithmetic-for-Point arms] [Point-constructor prior-subject]]
```

Method resolution for `x.method(args)` where `x: T`:

1. Walk subject tree
2. Find arm named `method` where target type = `T`
3. Emit Nock to grab arm at that axis and slam

Name collisions:  disallowed in v1. Two traits with same method name = compile error. (Skip syntax `^` deferred.)

What I feel like would work better is a Dojo-style wrapping of everything in a `=~`, that way we don't have to explicitly compose everything.

### Hoon Interop

```swift
let result: Noun = hoon.some-gate(arg)
let typed: MyStruct = result as! MyStruct
```

- Hoon calls return `Noun`.
- `as!` does runtime mold check (Hoon `;;` semantics).
- "Duck typing" at boundary: if noun shape matches, it works.

Jock always lets you lose type, sort of its version of `unsafe`.  It just loses type when you use things like the Hoon FFI for most things that aren't simple.  Then you use an `as` or `?` option variant to reassert type natively.

### Inference Rules Summary

Some initial thoughts, nothing binding here.  It would be far more permissive than Hoon.

|Context|Inference|
|---|---|
|Function params|Explicit required|
|Function return|Explicit required|
|Lambda params|Explicit required|
|Lambda return|Explicit required|
|`let` binding|Inferred from RHS, or explicit|
|Generic type params|Inferred from arguments at call site|
|Empty collections|Explicit annotation required|
|Mixed numeric literals|Unify to supertype|
|Binary ops across types|Determined by operator's trait impl|

### Naming

|Convention|Usage|
|---|---|
|`kebab-case`|variables, functions, fields|
|`PascalCase`|structs, traits, unions|
|`T`, `U`|type parameters|

* `x-1` = variable name
* `x - 1` = subtraction (mandatory spacing).
* `x -1` pair with unary negation on second one

This is because otherwise you will have head tags from Hoon and external nouns which are both different as raw atoms and unparseable as snake case values.  BAD!

Oh, and primitive types of course.

| Type                    | Notes                                       |
| ----------------------- | ------------------------------------------- |
| `Atom` / `Uint`         | unsigned integer, untyped atom              |
| `Int` / `Sint`          | signed integer (ZigZag atom)                |
| `Hex`                   | `@x` not `@ux` (slightly different parsing) |
| `String`                | tape (`(list @tD)`) (note change here)      |
| `Chars`                 | cord (`@t`) (note change here)              |
| `Real` (64-bit default) | `Real16`, `Real32`, `Real64`, `Real128`     |
| `Logical`               | `true` / `false`                            |
| `Date`                  | `@da`                                       |
| `Span`                  | `@dr`                                       |
| `Noun`                  | noun (untyped escape hatch)                 |

### Compound Types

| Type         | Syntax                   | Hoon equivalent                       |
| ------------ | ------------------------ | ------------------------------------- |
| Cell / Tuple | `(a b c)`                | cell (but as `+unit` so can be empty) |
| List         | `[a b c]`                | `+list` (already can be empty, `~`)   |
| Set          | `{a b c}`                | `+set` (ditto)                        |
| Dict         | `{k: v}` (empty: `{:}`)  | `+map` (ditto)                        |
| Vector       | `<a b c>` (could change) | Lagoon `$ndray`                       |
| Option       | ?a                       | `+unit`                               |

Types necessary for NockApp kernel:

```hoon
+$  goof    [mote=term =tang]
+$  wire    path
+$  ovum    [=wire =input]
+$  crud    [=goof =input]
+$  input   [eny=@ our=@ux now=@da cause=*]
```

```jock
alias Tang List<Chars>;
alias Term Chars;  // for now

struct Goof {
  mote: Term
  tang: Tang
}

alias Wire Path;

struct Input {
  eny: Uint
  our: Hex
  now: Date
  cause: Noun
}

struct Ovum {
  wire: Wire
  input: Input
}

struct Crud {
  goof: Goof
  input: Input
}
```
